### PR TITLE
Remove static mutable fields

### DIFF
--- a/sandbox/PerfBenchmarkDotNet/Program.cs
+++ b/sandbox/PerfBenchmarkDotNet/Program.cs
@@ -213,13 +213,13 @@ namespace PerfBenchmarkDotNet
         [Benchmark]
         public byte[] MessagePackSerializer_Serialize_TypelessContractlessStandardResolver_primitive()
         {
-            return newmsgpack::MessagePack.MessagePackSerializer.Serialize(TestTypelessPrimitiveType, newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance);
+            return newmsgpack::MessagePack.MessagePackSerializer.Serialize(TestTypelessPrimitiveType, new newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver());
         }
 
         [Benchmark]
         public byte[] MessagePackSerializer_Serialize_TypelessContractlessStandardResolver_complex()
         {
-            return newmsgpack::MessagePack.MessagePackSerializer.Serialize(TestTypelessComplexType, newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance);
+            return newmsgpack::MessagePack.MessagePackSerializer.Serialize(TestTypelessComplexType, new newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver());
         }
     }
 
@@ -233,8 +233,8 @@ namespace PerfBenchmarkDotNet
 
         private byte[] NewStandardResolverBytes = newmsgpack::MessagePack.MessagePackSerializer.Serialize(new ContractType("John", new ContractType("Jack", null)), newmsgpack::MessagePack.Resolvers.StandardResolver.Instance);
         private byte[] NewContractlessStandardResolverBytes = newmsgpack::MessagePack.MessagePackSerializer.Serialize(new ContractlessType("John", new ContractlessType("Jack", null)), newmsgpack::MessagePack.Resolvers.ContractlessStandardResolver.Instance);
-        private byte[] NewTypelessContractlessStandardResolverBytes = newmsgpack::MessagePack.MessagePackSerializer.Serialize(new TypelessPrimitiveType("John", 555), newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance);
-        private byte[] NewTypelessContractlessStandardResolverComplexBytes = newmsgpack::MessagePack.MessagePackSerializer.Serialize(new TypelessPrimitiveType("John", new TypelessPrimitiveType("John", null)), newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance);
+        private byte[] NewTypelessContractlessStandardResolverBytes = newmsgpack::MessagePack.MessagePackSerializer.Serialize(new TypelessPrimitiveType("John", 555), new newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver());
+        private byte[] NewTypelessContractlessStandardResolverComplexBytes = newmsgpack::MessagePack.MessagePackSerializer.Serialize(new TypelessPrimitiveType("John", new TypelessPrimitiveType("John", null)), new newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver());
 
         [Benchmark]
         public ContractType Old_MessagePackSerializer_Deserialize_StandardResolver()
@@ -275,13 +275,13 @@ namespace PerfBenchmarkDotNet
         [Benchmark]
         public TypelessPrimitiveType MessagePackSerializer_Deserialize_TypelessContractlessStandardResolver()
         {
-            return newmsgpack::MessagePack.MessagePackSerializer.Deserialize<TypelessPrimitiveType>(NewTypelessContractlessStandardResolverBytes, newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance);
+            return newmsgpack::MessagePack.MessagePackSerializer.Deserialize<TypelessPrimitiveType>(NewTypelessContractlessStandardResolverBytes, new newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver());
         }
 
         [Benchmark]
         public TypelessPrimitiveType MessagePackSerializer_Deserialize_TypelessContractlessStandardResolverComplexBytes()
         {
-            return newmsgpack::MessagePack.MessagePackSerializer.Deserialize<TypelessPrimitiveType>(NewTypelessContractlessStandardResolverComplexBytes, newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance);
+            return newmsgpack::MessagePack.MessagePackSerializer.Deserialize<TypelessPrimitiveType>(NewTypelessContractlessStandardResolverComplexBytes, new newmsgpack::MessagePack.Resolvers.TypelessContractlessStandardResolver());
         }
     }
 

--- a/src/MessagePack/Formatters/IMessagePackFormatter.cs
+++ b/src/MessagePack/Formatters/IMessagePackFormatter.cs
@@ -1,15 +1,9 @@
-﻿
-namespace MessagePack.Formatters
+﻿namespace MessagePack.Formatters
 {
-    // marker
-    public interface IMessagePackFormatter
-    {
-
-    }
-
-    public interface IMessagePackFormatter<T> : IMessagePackFormatter
+    public interface IMessagePackFormatter<T>
     {
         int Serialize(ref byte[] bytes, int offset, T value, IFormatterResolver formatterResolver);
+
         T Deserialize(byte[] bytes, int offset, IFormatterResolver formatterResolver, out int readSize);
     }
 }

--- a/src/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
+++ b/src/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
@@ -2,7 +2,11 @@
 
 namespace MessagePack.Internal
 {
-    // Safe for multiple-read, single-write.
+    /// <summary>
+    /// A dictionary where <see cref="Type"/> is the key, and a configurable <typeparamref name="TValue"/> type
+    /// that is thread-safe, allowing concurrent reads and exclusive writes.
+    /// </summary>
+    /// <typeparam name="TValue">The type of value stored in the dictionary.</typeparam>
     internal class ThreadsafeTypeKeyHashTable<TValue>
     {
         Entry[] buckets;

--- a/src/MessagePack/LZ4/LZ4MessagePackSerializer.Typeless.cs
+++ b/src/MessagePack/LZ4/LZ4MessagePackSerializer.Typeless.cs
@@ -14,7 +14,7 @@ namespace MessagePack
     {
         public static class Typeless
         {
-            static IFormatterResolver defaultResolver = MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance;
+            static IFormatterResolver defaultResolver = new TypelessContractlessStandardResolver();
 
             public static void RegisterDefaultResolver(params IFormatterResolver[] resolvers)
             {

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -22,11 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LZ4\Codec\LZ4Codec.Safe.cs" />
-    <None Include="MessagePackSerializer.Typeless.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />

--- a/src/MessagePack/MessagePackSerializer.Typeless.cs
+++ b/src/MessagePack/MessagePackSerializer.Typeless.cs
@@ -14,7 +14,7 @@ namespace MessagePack
     {
         public static class Typeless
         {
-            static IFormatterResolver defaultResolver = MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance;
+            static IFormatterResolver defaultResolver = new TypelessContractlessStandardResolver();
 
             public static void RegisterDefaultResolver(params IFormatterResolver[] resolvers)
             {

--- a/src/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack/MessagePackSerializer.cs
@@ -9,50 +9,20 @@ namespace MessagePack
     /// </summary>
     public static partial class MessagePackSerializer
     {
-        static IFormatterResolver defaultResolver;
-
         /// <summary>
-        /// FormatterResolver that used resolver less overloads. If does not set it, used StandardResolver.
+        /// Gets the default <see cref="IFormatterResolver"/> instance to use when one is not specified.
         /// </summary>
-        public static IFormatterResolver DefaultResolver
-        {
-            get
-            {
-                if (defaultResolver == null)
-                {
-                    defaultResolver = MessagePack.Resolvers.StandardResolver.Instance;
-                }
-
-                return defaultResolver;
-            }
-        }
-
-        /// <summary>
-        /// Is resolver decided?
-        /// </summary>
-        public static bool IsInitialized
-        {
-            get
-            {
-                return defaultResolver != null;
-            }
-        }
-
-        /// <summary>
-        /// Set default resolver of MessagePackSerializer APIs.
-        /// </summary>
-        /// <param name="resolver"></param>
-        public static void SetDefaultResolver(IFormatterResolver resolver)
-        {
-            defaultResolver = resolver;
-        }
+        /// <value>
+        /// This is the <see cref="Resolvers.StandardResolver"/>.
+        /// </value>
+        public static IFormatterResolver DefaultResolver => Resolvers.StandardResolver.Instance;
 
         /// <summary>
         /// Serialize to binary with default resolver.
         /// </summary>
         public static byte[] Serialize<T>(T obj)
         {
-            return Serialize(obj, defaultResolver);
+            return Serialize(obj, DefaultResolver);
         }
 
         /// <summary>
@@ -76,7 +46,7 @@ namespace MessagePack
         /// </summary>
         public static ArraySegment<byte> SerializeUnsafe<T>(T obj)
         {
-            return SerializeUnsafe(obj, defaultResolver);
+            return SerializeUnsafe(obj, DefaultResolver);
         }
 
         /// <summary>
@@ -100,7 +70,7 @@ namespace MessagePack
         /// </summary>
         public static void Serialize<T>(Stream stream, T obj)
         {
-            Serialize(stream, obj, defaultResolver);
+            Serialize(stream, obj, DefaultResolver);
         }
 
         /// <summary>
@@ -134,7 +104,7 @@ namespace MessagePack
         /// </summary>
         public static System.Threading.Tasks.Task SerializeAsync<T>(Stream stream, T obj)
         {
-            return SerializeAsync(stream, obj, defaultResolver);
+            return SerializeAsync(stream, obj, DefaultResolver);
         }
 
         /// <summary>
@@ -164,7 +134,7 @@ namespace MessagePack
 
         public static T Deserialize<T>(byte[] bytes)
         {
-            return Deserialize<T>(bytes, defaultResolver);
+            return Deserialize<T>(bytes, DefaultResolver);
         }
 
         public static T Deserialize<T>(byte[] bytes, IFormatterResolver resolver)
@@ -178,7 +148,7 @@ namespace MessagePack
 
         public static T Deserialize<T>(ArraySegment<byte> bytes)
         {
-            return Deserialize<T>(bytes, defaultResolver);
+            return Deserialize<T>(bytes, DefaultResolver);
         }
 
         public static T Deserialize<T>(ArraySegment<byte> bytes, IFormatterResolver resolver)
@@ -192,7 +162,7 @@ namespace MessagePack
 
         public static T Deserialize<T>(Stream stream)
         {
-            return Deserialize<T>(stream, defaultResolver);
+            return Deserialize<T>(stream, DefaultResolver);
         }
 
         public static T Deserialize<T>(Stream stream, IFormatterResolver resolver)
@@ -202,7 +172,7 @@ namespace MessagePack
 
         public static T Deserialize<T>(Stream stream, bool readStrict)
         {
-            return Deserialize<T>(stream, defaultResolver, readStrict);
+            return Deserialize<T>(stream, DefaultResolver, readStrict);
         }
 
         public static T Deserialize<T>(Stream stream, IFormatterResolver resolver, bool readStrict)
@@ -258,7 +228,7 @@ namespace MessagePack
 
         public static System.Threading.Tasks.Task<T> DeserializeAsync<T>(Stream stream)
         {
-            return DeserializeAsync<T>(stream, defaultResolver);
+            return DeserializeAsync<T>(stream, DefaultResolver);
         }
 
         // readStrict async read is too slow(many Task garbage) so I don't provide async option.

--- a/src/MessagePack/Resolvers/CachingFormatterResolver.cs
+++ b/src/MessagePack/Resolvers/CachingFormatterResolver.cs
@@ -1,0 +1,39 @@
+﻿#if NETSTANDARD || NETFRAMEWORK
+
+using MessagePack.Formatters;
+using MessagePack.Internal;
+
+namespace MessagePack.Resolvers
+{
+    /// <summary>
+    /// A base class for <see cref="IFormatterResolver"/> classes that want to cache their responses for perf reasons.
+    /// </summary>
+    internal abstract class CachingFormatterResolver : IFormatterResolver
+    {
+        /// <summary>
+        /// The cache of types to their formatters.
+        /// </summary>
+        private readonly ThreadsafeTypeKeyHashTable<object> formatters = new ThreadsafeTypeKeyHashTable<object>();
+
+        /// <inheritdoc />
+        public IMessagePackFormatter<T> GetFormatter<T>()
+        {
+            if (!this.formatters.TryGetValue(typeof(T), out object formatter))
+            {
+                formatter = this.GetFormatterCore<T>();
+                this.formatters.TryAdd(typeof(T), formatter);
+            }
+
+            return (IMessagePackFormatter<T>)formatter;
+        }
+
+        /// <summary>
+        /// Looks up a formatter for a type that has not been previously cached.
+        /// </summary>
+        /// <typeparam name="T">The type to be formatted.</typeparam>
+        /// <returns>The formatter to use, or <c>null</c> if none found.</returns>
+        protected abstract IMessagePackFormatter<T> GetFormatterCore<T>();
+    }
+}
+
+#endif

--- a/src/MessagePack/Resolvers/TypelessObjectResolver.cs
+++ b/src/MessagePack/Resolvers/TypelessObjectResolver.cs
@@ -10,35 +10,35 @@ namespace MessagePack.Resolvers
     /// <summary>
     /// Used for `object` fields/collections, ex: var arr = new object[] { 1, "a", new Model() };
     /// The runtime type of value in object field, should be covered by one of resolvers in complex/standard resolver.
-    /// TypelessObjectResolver should be placed before DynamicObjectTypeFallbackResolver and PrimitiveObjectFormatter in resolvers list.
-    /// Deserializer uses Namescape.TypeName, AssemblyName to get runtime type in destination app, so that combination must be present in destination app.
+    /// <see cref="TypelessObjectResolver"/> should be placed before DynamicObjectTypeFallbackResolver and <see cref="PrimitiveObjectFormatter"/> in resolvers list.
+    /// Deserializer uses Namespace.TypeName, AssemblyName to get runtime type in destination app, so that combination must be present in destination app.
     /// Serialized binary is valid MessagePack binary used ext-format and custom typecode(100).
     /// Inside ext - assembly qualified type name, and serialized object
     /// </summary>
     public sealed class TypelessObjectResolver : IFormatterResolver
     {
-        public static IFormatterResolver Instance = new TypelessObjectResolver();
+        /// <summary>
+        /// Backing field for the <see cref="Formatter"/> property.
+        /// </summary>
+        private TypelessFormatter formatter = new TypelessFormatter();
 
-        TypelessObjectResolver()
+        /// <summary>
+        /// Gets or sets the <see cref="TypelessFormatter"/> used when serializing/deserializing values typed as <see cref="object"/>/
+        /// </summary>
+        /// <value>A instance of a formatter. Never null.</value>
+        /// <exception cref="ArgumentNullException">Thrown if assigned a value of null.</exception>
+        public TypelessFormatter Formatter
         {
-
+            get => this.formatter;
+            set => this.formatter = value ?? throw new ArgumentNullException(nameof(value));
         }
 
+        /// <inheritdoc />
         public IMessagePackFormatter<T> GetFormatter<T>()
         {
-            return FormatterCache<T>.formatter;
-        }
-
-        static class FormatterCache<T>
-        {
-            public static readonly IMessagePackFormatter<T> formatter;
-
-            static FormatterCache()
-            {
-                formatter = (typeof(T) == typeof(object))
-                    ? (IMessagePackFormatter<T>)(object)TypelessFormatter.Instance
-                    : null;
-            }
+            return typeof(T) == typeof(object)
+                ? (IMessagePackFormatter<T>)(object)this.Formatter
+                : null;
         }
     }
 

--- a/tests/MessagePack.Tests/TypelessContractlessStandardResolverTest.cs
+++ b/tests/MessagePack.Tests/TypelessContractlessStandardResolverTest.cs
@@ -41,11 +41,11 @@ namespace MessagePack.Tests
                     }
             };
 
-            var result = MessagePackSerializer.Serialize(p, TypelessContractlessStandardResolver.Instance);
+            var result = MessagePackSerializer.Serialize(p, new TypelessContractlessStandardResolver());
 
             MessagePackSerializer.ToJson(result).Is(@"{""Name"":""John"",""Addresses"":[{""Street"":""St.""},{""Street"":""Ave.""}]}");
 
-            var p2 = MessagePackSerializer.Deserialize<Person>(result, TypelessContractlessStandardResolver.Instance);
+            var p2 = MessagePackSerializer.Deserialize<Person>(result, new TypelessContractlessStandardResolver());
             p2.Name.Is("John");
             var addresses = p2.Addresses as IList;
             var d1 = addresses[0] as IDictionary;
@@ -67,9 +67,9 @@ namespace MessagePack.Tests
                 }
             };
 
-            var result = MessagePackSerializer.Serialize(p, TypelessContractlessStandardResolver.Instance);
+            var result = MessagePackSerializer.Serialize(p, new TypelessContractlessStandardResolver());
 
-            var p2 = MessagePackSerializer.Deserialize<Person>(result, TypelessContractlessStandardResolver.Instance);
+            var p2 = MessagePackSerializer.Deserialize<Person>(result, new TypelessContractlessStandardResolver());
             p.IsStructuralEqual(p2);
 
             MessagePackSerializer.ToJson(result).Is(@"{""Name"":""John"",""Addresses"":[{""$type"":""MessagePack.Tests.TypelessContractlessStandardResolverTest+Address, MessagePack.Tests"",""Street"":""St.""},{""$type"":""MessagePack.Tests.TypelessContractlessStandardResolverTest+Address, MessagePack.Tests"",""Street"":""Ave.""}]}");
@@ -88,9 +88,9 @@ namespace MessagePack.Tests
                 }
             };
 
-            var result = MessagePackSerializer.Serialize(p, TypelessContractlessStandardResolver.Instance);
+            var result = MessagePackSerializer.Serialize(p, new TypelessContractlessStandardResolver());
 
-            var p2 = MessagePackSerializer.Deserialize<Person>(result, TypelessContractlessStandardResolver.Instance);
+            var p2 = MessagePackSerializer.Deserialize<Person>(result, new TypelessContractlessStandardResolver());
             p.IsStructuralEqual(p2);
 
 #if NETFRAMEWORK
@@ -107,7 +107,7 @@ namespace MessagePack.Tests
         public void TypelessContractlessTest()
         {
             object obj = new B() { Nested = new A() { Id = 1 } };
-            var result = MessagePackSerializer.Serialize(obj, TypelessContractlessStandardResolver.Instance);
+            var result = MessagePackSerializer.Serialize(obj, new TypelessContractlessStandardResolver());
             MessagePackSerializer.ToJson(result).Is(@"{""$type"":""MessagePack.Tests.TypelessContractlessStandardResolverTest+B, MessagePack.Tests"",""Nested"":{""Id"":1}}");
         }
 
@@ -120,7 +120,7 @@ namespace MessagePack.Tests
         public void TypelessAttributedTest()
         {
             object obj = new BC() { Nested = new AC() { Id = 1 }, Name = "Zed" };
-            var result = MessagePackSerializer.Serialize(obj, TypelessContractlessStandardResolver.Instance);
+            var result = MessagePackSerializer.Serialize(obj, new TypelessContractlessStandardResolver());
             MessagePackSerializer.ToJson(result).Is(@"[""MessagePack.Tests.TypelessContractlessStandardResolverTest+BC, MessagePack.Tests"",[1],""Zed""]");
         }
 
@@ -132,9 +132,9 @@ namespace MessagePack.Tests
                 { (byte)1, "a"},
                 { (byte)2, new object[] { "level2", new object[] { "level3", new Person() { Name = "Peter", Addresses = new object[] { new Address() { Street = "St." }, new DateTime(2017,6,26,14,58,0) } } } } }
             };
-            var result = MessagePackSerializer.Serialize(arr, TypelessContractlessStandardResolver.Instance);
+            var result = MessagePackSerializer.Serialize(arr, new TypelessContractlessStandardResolver());
 
-            var deser = MessagePackSerializer.Deserialize<Dictionary<object, object>>(result, TypelessContractlessStandardResolver.Instance);
+            var deser = MessagePackSerializer.Deserialize<Dictionary<object, object>>(result, new TypelessContractlessStandardResolver());
             deser.IsStructuralEqual(arr);
 
 #if NETFRAMEWORK
@@ -148,8 +148,8 @@ namespace MessagePack.Tests
         public void PreservingCollectionTypeTest()
         {
             var arr = new object[] { (byte)1, new object[] { (byte)2, new LinkedList<object>(new object[] { "a", (byte)42 }) } };
-            var result = MessagePackSerializer.Serialize(arr, TypelessContractlessStandardResolver.Instance);
-            var deser = MessagePackSerializer.Deserialize<object[]>(result, TypelessContractlessStandardResolver.Instance);
+            var result = MessagePackSerializer.Serialize(arr, new TypelessContractlessStandardResolver());
+            var deser = MessagePackSerializer.Deserialize<object[]>(result, new TypelessContractlessStandardResolver());
             deser.IsStructuralEqual(arr);
 
 #if NETFRAMEWORK
@@ -259,9 +259,9 @@ namespace MessagePack.Tests
                     Obj = new string[] { "asd", "asd" }
                 };
 
-                var objSer = MessagePackSerializer.Serialize(objRaw, TypelessContractlessStandardResolver.Instance);
+                var objSer = MessagePackSerializer.Serialize(objRaw, new TypelessContractlessStandardResolver());
 
-                var objDes = MessagePackSerializer.Deserialize<SomeClass>(objSer, TypelessContractlessStandardResolver.Instance);
+                var objDes = MessagePackSerializer.Deserialize<SomeClass>(objSer, new TypelessContractlessStandardResolver());
 
                 var expectedTrue = objDes.Obj is string[];
                 expectedTrue.IsTrue();


### PR DESCRIPTION
The configuration model for MessagePack in v1.x is all about statics, and mutating AppDomain-wide state to get it to behave the way you want. This isn't good when you have a variety of libraries in an AppDomain all using MessagePack for different purposes at once.

In this PR, I start to remove the static fields that offer mutable state. In their place, I use instance fields, allowing each user to customize all they want. Given that instances are mutable (by design), it means we can't proffer up public static fields with 'default' instances for these objects either, since that would once again be mutating state that is shared at a static level. So I'm removing these static `Instance` properties in favor of each caller creating their own instance.

Part of the overall fix for #8