### PR TITLE
Hide LZ7 codec

### DIFF
--- a/src/MessagePack/LZ4/Codec/LZ4Codec.Helper.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.Helper.cs
@@ -2,7 +2,7 @@
 
 namespace MessagePack.LZ4
 {
-    public static partial class LZ4Codec
+    partial class LZ4Codec
     {
 #if NETSTANDARD
 

--- a/src/MessagePack/LZ4/Codec/LZ4Codec.Safe.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.Safe.cs
@@ -34,7 +34,7 @@ using System.Diagnostics;
 namespace MessagePack.LZ4
 {
     /// <summary>Safe LZ4 codec.</summary>
-    public static partial class LZ4Codec
+    partial class LZ4Codec
     {
         #region Helper
 

--- a/src/MessagePack/LZ4/Codec/LZ4Codec.Safe32.Dirty.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.Safe32.Dirty.cs
@@ -70,7 +70,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace MessagePack.LZ4
 {
-    public static partial class LZ4Codec
+    partial class LZ4Codec
     {
         #region LZ4_compressCtx
 

--- a/src/MessagePack/LZ4/Codec/LZ4Codec.Safe64.Dirty.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.Safe64.Dirty.cs
@@ -70,7 +70,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace MessagePack.LZ4
 {
-    public static partial class LZ4Codec
+    partial class LZ4Codec
     {
         #region LZ4_compressCtx
 

--- a/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe.cs
@@ -32,7 +32,7 @@ using System;
 namespace MessagePack.LZ4
 {
     /// <summary>Unsafe LZ4 codec.</summary>
-    public static partial class LZ4Codec
+    partial class LZ4Codec
     {
         /// <summary>Copies block of memory.</summary>
         /// <param name="src">The source.</param>

--- a/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe32.Dirty.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe32.Dirty.cs
@@ -70,7 +70,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace MessagePack.LZ4
 {
-    public static partial class LZ4Codec
+    partial class LZ4Codec
     {
         #region LZ4_compressCtx_32
 

--- a/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe64.Dirty.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe64.Dirty.cs
@@ -70,7 +70,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace MessagePack.LZ4
 {
-    public static partial class LZ4Codec
+    partial class LZ4Codec
     {
         #region LZ4_compressCtx_64
 

--- a/src/MessagePack/LZ4/Codec/LZ4Codec.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.cs
@@ -31,7 +31,7 @@ using System;
 
 namespace MessagePack.LZ4
 {
-    public static partial class LZ4Codec
+    internal static partial class LZ4Codec
     {
         #region configuration
 


### PR DESCRIPTION
Nothing outside the project but within the solution was using these public types.
MessagePack is a serialization library, and shouldn't be exposing implementation details or direct access to the LZ7 codec.

Toward overall fix for #7 