### PR TITLE
Support [DataContract] types that lack explicit [IgnoreMember] attributes

### DIFF
--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1426,7 +1426,9 @@ typeof(int), typeof(int) });
                         var pseudokey = item.GetCustomAttribute<DataMemberAttribute>(true);
                         if (pseudokey == null)
                         {
-                            throw new MessagePackDynamicObjectResolverException("all public members must mark DataMemberAttribute or IgnoreMemberAttribute." + " type: " + type.FullName + " member:" + item.Name);
+                            // This member has no DataMemberAttribute nor IgnoreMemberAttribute.
+                            // But the type *did* have a DataContractAttribute on it, so no attribute implies the member should not be serialized.
+                            continue;
                         }
 
                         // use Order first
@@ -1507,7 +1509,9 @@ typeof(int), typeof(int) });
                         var pseudokey = item.GetCustomAttribute<DataMemberAttribute>(true);
                         if (pseudokey == null)
                         {
-                            throw new MessagePackDynamicObjectResolverException("all public members must mark DataMemberAttribute or IgnoreMemberAttribute." + " type: " + type.FullName + " member:" + item.Name);
+                            // This member has no DataMemberAttribute nor IgnoreMemberAttribute.
+                            // But the type *did* have a DataContractAttribute on it, so no attribute implies the member should not be serialized.
+                            continue;
                         }
 
                         // use Order first

--- a/tests/MessagePack.Tests/DataContractTest.cs
+++ b/tests/MessagePack.Tests/DataContractTest.cs
@@ -37,6 +37,26 @@ namespace MessagePack.Tests
             public string MyProperty2;
         }
 
+        [DataContract]
+        public class ClassWithPublicMembersWithoutAttributes
+        {
+            [DataMember]
+            public int AttributedProperty { get; set; }
+
+            public int UnattributedProperty { get; set; }
+
+            [IgnoreDataMember]
+            public int IgnoredProperty { get; set; }
+
+            [DataMember]
+            public int AttributedField;
+
+            public int UnattributedField;
+
+            [IgnoreDataMember]
+            public int IgnoredField;
+        }
+
         [Fact]
         public void SerializeOrder()
         {
@@ -78,6 +98,32 @@ namespace MessagePack.Tests
             mc.MyProperty2.Is(mc2.MyProperty2);
 
             MessagePackSerializer.ToJson(bin).Is(@"{""MyProperty1"":100,""MyProperty2"":""foobar""}");
+        }
+
+        [Fact]
+        public void Serialize_WithVariousAttributes()
+        {
+            var mc = new ClassWithPublicMembersWithoutAttributes {
+                AttributedProperty = 1,
+                UnattributedProperty = 2,
+                IgnoredProperty = 3,
+                AttributedField = 4,
+                UnattributedField = 5,
+                IgnoredField = 6,
+            };
+
+            var bin = serializer.Serialize(mc);
+            var mc2 = serializer.Deserialize<ClassWithPublicMembersWithoutAttributes>(bin);
+
+            mc2.AttributedProperty.Is(mc.AttributedProperty);
+            mc2.AttributedField.Is(mc.AttributedField);
+
+            mc2.UnattributedProperty.Is(0);
+            mc2.IgnoredProperty.Is(0);
+            mc2.UnattributedField.Is(0);
+            mc2.IgnoredField.Is(0);
+
+            serializer.ToJson(bin).Is(@"{""AttributedProperty"":1,""AttributedField"":4}");
         }
     }
 }


### PR DESCRIPTION
Support `[DataContract]` types that lack explicit `[IgnoreMember]` attributes

Fixes neuecc#292
Fixes #18