### PR TITLE
don't use the attributes to control target framework when combined with EtwProfiler (a BDN bug)

### DIFF
--- a/sandbox/PerfBenchmarkDotNet/MessagePackWriterBenchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/MessagePackWriterBenchmark.cs
@@ -3,15 +3,12 @@ extern alias oldmsgpack;
 
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Diagnostics.Windows.Configs;
 using Nerdbank.Streams;
 
 namespace PerfBenchmarkDotNet
 {
-    [ClrJob(baseline: true), CoreJob]
     [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
     [CategoriesColumn]
-    [EtwProfiler]
     public class MessagePackWriterBenchmark
     {
         private const int RepsOverArray = 100 * 1024;


### PR DESCRIPTION
It's just a workaround to unblock @AArnott 

Instead of using attributes, you need to use console line arguments:

```
--runtimes net47 netcoreapp2.2 --profiler ETW
```

or the simpler version:

```
-r net47 netcoreapp2.2 -p ETW
```

The first runtime provided in the list is always marked as baseline.