### PR TITLE
Use ReadOnlySpan<byte> instead of ArraySegment<byte>

### DIFF
--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -31,6 +31,9 @@
     <Compile Include="..\..\src\MessagePack\Internal\ByteArrayStringHashTable.cs">
       <Link>Code\ByteArrayStringHashTable.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\MessagePack\Internal\CodeGenHelpers.cs">
+      <Link>Code\CodeGenHelpers.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\MessagePack\Internal\DynamicAssembly.cs">
       <Link>Code\DynamicAssembly.cs</Link>
     </Compile>
@@ -76,5 +79,8 @@
     <Compile Include="..\SharedData\Class1.cs">
       <Link>Class1.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/sandbox/PerfBenchmarkDotNet/Program.cs
+++ b/sandbox/PerfBenchmarkDotNet/Program.cs
@@ -570,7 +570,7 @@ namespace PerfBenchmarkDotNet
         {
             for (int i = 0; i < keys.Length; i++)
             {
-                automata.TryGetValue(keys[i], 0, keys[i].Length, out _);
+                automata.TryGetValue(keys[i], out _);
             }
         }
 
@@ -1025,7 +1025,7 @@ namespace GeneratedFormatter
                 {
                     int num4;
                     var segment = MessagePackBinary.ReadStringSegment(bytes, num, out ptr);
-                    bool arg_47_0 = this.keyMapping.TryGetValueSafe(segment, out num4);
+                    bool arg_47_0 = this.keyMapping.TryGetValue(segment, out num4);
                     num += ptr;
                     if (!arg_47_0)
                     {
@@ -1155,7 +1155,7 @@ namespace GeneratedFormatter
                     var stringKey = newmsgpack::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                     offset += readSize;
                     int key;
-                    if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                    if (!____keyMapping.TryGetValue(stringKey, out key))
                     {
                         readSize = newmsgpack::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                         goto NEXT_LOOP;

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -1018,7 +1018,7 @@ namespace MessagePack.Formatters.SharedData
                 var stringKey = global::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                 offset += readSize;
                 int key;
-                if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                if (!____keyMapping.TryGetValue(stringKey, out key))
                 {
                     readSize = global::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                     goto NEXT_LOOP;
@@ -1171,7 +1171,7 @@ namespace MessagePack.Formatters.SharedData
                 var stringKey = global::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                 offset += readSize;
                 int key;
-                if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                if (!____keyMapping.TryGetValue(stringKey, out key))
                 {
                     readSize = global::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                     goto NEXT_LOOP;
@@ -1994,7 +1994,7 @@ namespace MessagePack.Formatters.SharedData
                 var stringKey = global::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                 offset += readSize;
                 int key;
-                if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                if (!____keyMapping.TryGetValue(stringKey, out key))
                 {
                     readSize = global::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                     goto NEXT_LOOP;
@@ -2074,7 +2074,7 @@ namespace MessagePack.Formatters.SharedData
                 var stringKey = global::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                 offset += readSize;
                 int key;
-                if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                if (!____keyMapping.TryGetValue(stringKey, out key))
                 {
                     readSize = global::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                     goto NEXT_LOOP;
@@ -2809,7 +2809,7 @@ namespace MessagePack.Formatters.SharedData
                 var stringKey = global::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                 offset += readSize;
                 int key;
-                if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                if (!____keyMapping.TryGetValue(stringKey, out key))
                 {
                     readSize = global::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                     goto NEXT_LOOP;
@@ -2943,7 +2943,7 @@ namespace MessagePack.Formatters.SharedData
                 var stringKey = global::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                 offset += readSize;
                 int key;
-                if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                if (!____keyMapping.TryGetValue(stringKey, out key))
                 {
                     readSize = global::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                     goto NEXT_LOOP;
@@ -4017,7 +4017,7 @@ namespace MessagePack.Formatters
                 var stringKey = global::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                 offset += readSize;
                 int key;
-                if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                if (!____keyMapping.TryGetValue(stringKey, out key))
                 {
                     readSize = global::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                     goto NEXT_LOOP;
@@ -4144,7 +4144,7 @@ namespace MessagePack.Formatters
                 var stringKey = global::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                 offset += readSize;
                 int key;
-                if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                if (!____keyMapping.TryGetValue(stringKey, out key))
                 {
                     readSize = global::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                     goto NEXT_LOOP;
@@ -4301,7 +4301,7 @@ namespace MessagePack.Formatters.PerfBenchmarkDotNet
                 var stringKey = global::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                 offset += readSize;
                 int key;
-                if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                if (!____keyMapping.TryGetValue(stringKey, out key))
                 {
                     readSize = global::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                     goto NEXT_LOOP;

--- a/src/MessagePack.UniversalCodeGenerator/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.UniversalCodeGenerator/Generator/FormatterTemplate.cs
@@ -401,7 +401,7 @@ if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnBe
             this.Write(@"                var stringKey = global::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                 offset += readSize;
                 int key;
-                if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                if (!____keyMapping.TryGetValue(stringKey, out key))
                 {
                     readSize = global::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                     goto NEXT_LOOP;

--- a/src/MessagePack.UniversalCodeGenerator/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.UniversalCodeGenerator/Generator/FormatterTemplate.tt
@@ -108,7 +108,7 @@ namespace <#= Namespace #>
                 var stringKey = global::MessagePack.MessagePackBinary.ReadStringSegment(bytes, offset, out readSize);
                 offset += readSize;
                 int key;
-                if (!____keyMapping.TryGetValueSafe(stringKey, out key))
+                if (!____keyMapping.TryGetValue(stringKey, out key))
                 {
                     readSize = global::MessagePack.MessagePackBinary.ReadNextBlock(bytes, offset);
                     goto NEXT_LOOP;

--- a/src/MessagePack/FloatBits.cs
+++ b/src/MessagePack/FloatBits.cs
@@ -30,23 +30,23 @@ namespace MessagePack
             this.Value = value;
         }
 
-        public Float32Bits(byte[] bigEndianBytes, int offset)
+        public Float32Bits(ReadOnlySpan<byte> bigEndianBytes)
         {
             this = default(Float32Bits);
 
             if (BitConverter.IsLittleEndian)
             {
-                this.Byte0 = bigEndianBytes[offset + 3];
-                this.Byte1 = bigEndianBytes[offset + 2];
-                this.Byte2 = bigEndianBytes[offset + 1];
-                this.Byte3 = bigEndianBytes[offset];
+                this.Byte0 = bigEndianBytes[3];
+                this.Byte1 = bigEndianBytes[2];
+                this.Byte2 = bigEndianBytes[1];
+                this.Byte3 = bigEndianBytes[0];
             }
             else
             {
-                this.Byte0 = bigEndianBytes[offset];
-                this.Byte1 = bigEndianBytes[offset + 1];
-                this.Byte2 = bigEndianBytes[offset + 2];
-                this.Byte3 = bigEndianBytes[offset + 3];
+                this.Byte0 = bigEndianBytes[0];
+                this.Byte1 = bigEndianBytes[1];
+                this.Byte2 = bigEndianBytes[2];
+                this.Byte3 = bigEndianBytes[3];
             }
         }
     }
@@ -87,31 +87,31 @@ namespace MessagePack
             this.Value = value;
         }
 
-        public Float64Bits(byte[] bigEndianBytes, int offset)
+        public Float64Bits(ReadOnlySpan<byte> bigEndianBytes)
         {
             this = default(Float64Bits);
 
             if (BitConverter.IsLittleEndian)
             {
-                this.Byte0 = bigEndianBytes[offset + 7];
-                this.Byte1 = bigEndianBytes[offset + 6];
-                this.Byte2 = bigEndianBytes[offset + 5];
-                this.Byte3 = bigEndianBytes[offset + 4];
-                this.Byte4 = bigEndianBytes[offset + 3];
-                this.Byte5 = bigEndianBytes[offset + 2];
-                this.Byte6 = bigEndianBytes[offset + 1];
-                this.Byte7 = bigEndianBytes[offset];
+                this.Byte0 = bigEndianBytes[7];
+                this.Byte1 = bigEndianBytes[6];
+                this.Byte2 = bigEndianBytes[5];
+                this.Byte3 = bigEndianBytes[4];
+                this.Byte4 = bigEndianBytes[3];
+                this.Byte5 = bigEndianBytes[2];
+                this.Byte6 = bigEndianBytes[1];
+                this.Byte7 = bigEndianBytes[0];
             }
             else
             {
-                this.Byte0 = bigEndianBytes[offset];
-                this.Byte1 = bigEndianBytes[offset + 1];
-                this.Byte2 = bigEndianBytes[offset + 2];
-                this.Byte3 = bigEndianBytes[offset + 3];
-                this.Byte4 = bigEndianBytes[offset + 4];
-                this.Byte5 = bigEndianBytes[offset + 5];
-                this.Byte6 = bigEndianBytes[offset + 6];
-                this.Byte7 = bigEndianBytes[offset + 7];
+                this.Byte0 = bigEndianBytes[0];
+                this.Byte1 = bigEndianBytes[1];
+                this.Byte2 = bigEndianBytes[2];
+                this.Byte3 = bigEndianBytes[3];
+                this.Byte4 = bigEndianBytes[4];
+                this.Byte5 = bigEndianBytes[5];
+                this.Byte6 = bigEndianBytes[6];
+                this.Byte7 = bigEndianBytes[7];
             }
         }
     }

--- a/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -201,7 +201,7 @@ namespace MessagePack.Formatters
 
             bytes[offset] = MessagePackCode.Str8;
             bytes[offset + 1] = unchecked((byte)36);
-            new GuidBits(ref value).Write(bytes, offset + 2);
+            new GuidBits(ref value).Write(bytes.AsSpan(offset + 2));
             return 38;
         }
 

--- a/src/MessagePack/Internal/AsymmetricKeyHashTable.cs
+++ b/src/MessagePack/Internal/AsymmetricKeyHashTable.cs
@@ -34,7 +34,7 @@ namespace MessagePack.Internal
 
         public bool Equals(byte[] x, ArraySegment<byte> y)
         {
-            return ByteArrayComparer.Equals(y.Array, y.Offset, y.Count, x);
+            return ByteArrayComparer.Equals(y, x);
         }
 
         public int GetHashCode(byte[] key1)
@@ -48,11 +48,11 @@ namespace MessagePack.Internal
             {
                 if (Is32Bit)
                 {
-                    return (int)FarmHash.Hash32(key2.Array, key2.Offset, key2.Count);
+                    return (int)FarmHash.Hash32(key2);
                 }
                 else
                 {
-                    return (int)FarmHash.Hash64(key2.Array, key2.Offset, key2.Count);
+                    return (int)FarmHash.Hash64(key2);
                 }
             }
         }

--- a/src/MessagePack/Internal/AutomataDictionary.cs
+++ b/src/MessagePack/Internal/AutomataDictionary.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text;
 using System.Linq;
-using System.Reflection.Emit;
 using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace MessagePack.Internal
 {
@@ -12,7 +14,7 @@ namespace MessagePack.Internal
 
     public class AutomataDictionary : IEnumerable<KeyValuePair<string, int>>
     {
-        readonly AutomataNode root;
+        private readonly AutomataNode root;
 
         public AutomataDictionary()
         {
@@ -20,54 +22,46 @@ namespace MessagePack.Internal
         }
 
 #if !UNITY
-        public unsafe void Add(string str, int value)
+        public void Add(string str, int value)
         {
-            var bytes = Encoding.UTF8.GetBytes(str);
-            fixed (byte* buffer = &bytes[0])
+            ReadOnlySpan<byte> bytes = Encoding.UTF8.GetBytes(str);
+            var node = root;
+
+            while (bytes.Length > 0)
             {
-                var node = root;
+                var key = AutomataKeyGen.GetKey(ref bytes);
 
-                var p = buffer;
-                var rest = bytes.Length;
-                while (rest != 0)
+                if (bytes.Length == 0)
                 {
-                    var key = AutomataKeyGen.GetKey(ref p, ref rest);
-
-                    if (rest == 0)
-                    {
-                        node = node.Add(key, value, str);
-                    }
-                    else
-                    {
-                        node = node.Add(key);
-                    }
+                    node = node.Add(key, value, str);
+                }
+                else
+                {
+                    node = node.Add(key);
                 }
             }
         }
 
-        public unsafe bool TryGetValue(byte[] bytes, int offset, int count, out int value)
+        public bool TryGetValue(ReadOnlySequence<byte> bytes, out int value) => TryGetValue(bytes.ToArray(), out value);
+
+        public bool TryGetValue(ReadOnlySpan<byte> bytes, out int value)
         {
-            fixed (byte* p = &bytes[0])
+            var node = root;
+
+            while (bytes.Length > 0 && node != null)
             {
-                var p1 = p;
-                var node = root;
-                var rest = count;
+                node = node.SearchNext(ref bytes);
+            }
 
-                while (rest != 0 && node != null)
-                {
-                    node = node.SearchNext(ref p1, ref rest);
-                }
-
-                if (node == null)
-                {
-                    value = -1;
-                    return false;
-                }
-                else
-                {
-                    value = node.Value;
-                    return true;
-                }
+            if (node == null)
+            {
+                value = -1;
+                return false;
+            }
+            else
+            {
+                value = node.Value;
+                return true;
             }
         }
 #else
@@ -98,31 +92,6 @@ namespace MessagePack.Internal
 
 #endif
 
-
-        public bool TryGetValueSafe(ArraySegment<byte> key, out int value)
-        {
-            var node = root;
-            var bytes = key.Array;
-            var offset = key.Offset;
-            var rest = key.Count;
-
-            while (rest != 0 && node != null)
-            {
-                node = node.SearchNextSafe(bytes, ref offset, ref rest);
-            }
-
-            if (node == null)
-            {
-                value = -1;
-                return false;
-            }
-            else
-            {
-                value = node.Value;
-                return true;
-            }
-        }
-
         // for debugging
         public override string ToString()
         {
@@ -131,7 +100,7 @@ namespace MessagePack.Internal
             return sb.ToString();
         }
 
-        static void ToStringCore(IEnumerable<AutomataNode> nexts, StringBuilder sb, int depth)
+        private static void ToStringCore(IEnumerable<AutomataNode> nexts, StringBuilder sb, int depth)
         {
             foreach (var item in nexts)
             {
@@ -161,12 +130,19 @@ namespace MessagePack.Internal
             return YieldCore(this.root.YieldChildren()).GetEnumerator();
         }
 
-        static IEnumerable<KeyValuePair<string, int>> YieldCore(IEnumerable<AutomataNode> nexts)
+        private static IEnumerable<KeyValuePair<string, int>> YieldCore(IEnumerable<AutomataNode> nexts)
         {
             foreach (var item in nexts)
             {
-                if (item.Value != -1) yield return new KeyValuePair<string, int>(item.originalKey, item.Value);
-                foreach (var x in YieldCore(item.YieldChildren())) yield return x;
+                if (item.Value != -1)
+                {
+                    yield return new KeyValuePair<string, int>(item.originalKey, item.Value);
+                }
+
+                foreach (var x in YieldCore(item.YieldChildren()))
+                {
+                    yield return x;
+                }
             }
         }
 
@@ -174,25 +150,24 @@ namespace MessagePack.Internal
 
 #if !NET_STANDARD_2_0
 
-        public void EmitMatch(ILGenerator il, LocalBuilder p, LocalBuilder rest, LocalBuilder key, Action<KeyValuePair<string, int>> onFound, Action onNotFound)
+        public void EmitMatch(ILGenerator il, LocalBuilder bytesSpan, LocalBuilder key, Action<KeyValuePair<string, int>> onFound, Action onNotFound)
         {
-            root.EmitSearchNext(il, p, rest, key, onFound, onNotFound);
+            root.EmitSearchNext(il, bytesSpan, key, onFound, onNotFound);
         }
 
 #endif
 
-        class AutomataNode : IComparable<AutomataNode>
+        private class AutomataNode : IComparable<AutomataNode>
         {
-            static readonly AutomataNode[] emptyNodes = new AutomataNode[0];
-            static readonly ulong[] emptyKeys = new ulong[0];
+            private static readonly AutomataNode[] emptyNodes = new AutomataNode[0];
+            private static readonly ulong[] emptyKeys = new ulong[0];
 
             public ulong Key;
             public int Value;
             public string originalKey;
-
-            AutomataNode[] nexts;
-            ulong[] nextKeys;
-            int count;
+            private AutomataNode[] nexts;
+            private ulong[] nextKeys;
+            private int count;
 
             public bool HasChildren { get { return count != 0; } }
 
@@ -241,9 +216,9 @@ namespace MessagePack.Internal
 
 #if !UNITY
 
-            public unsafe AutomataNode SearchNext(ref byte* p, ref int rest)
+            public AutomataNode SearchNext(ref ReadOnlySpan<byte> value)
             {
-                var key = AutomataKeyGen.GetKey(ref p, ref rest);
+                var key = AutomataKeyGen.GetKey(ref value);
                 if (count < 4)
                 {
                     // linear search
@@ -270,33 +245,6 @@ namespace MessagePack.Internal
 
 #endif
 
-            public AutomataNode SearchNextSafe(byte[] p, ref int offset, ref int rest)
-            {
-                var key = AutomataKeyGen.GetKeySafe(p, ref offset, ref rest);
-                if (count < 4)
-                {
-                    // linear search
-                    for (int i = 0; i < count; i++)
-                    {
-                        if (nextKeys[i] == key)
-                        {
-                            return nexts[i];
-                        }
-                    }
-                }
-                else
-                {
-                    // binary search
-                    var index = BinarySearch(nextKeys, 0, count, key);
-                    if (index >= 0)
-                    {
-                        return nexts[index];
-                    }
-                }
-
-                return null;
-            }
-
             internal static int BinarySearch(ulong[] array, int index, int length, ulong value)
             {
                 int lo = index;
@@ -307,11 +255,24 @@ namespace MessagePack.Internal
 
                     var arrayValue = array[i];
                     int order;
-                    if (arrayValue < value) order = -1;
-                    else if (arrayValue > value) order = 1;
-                    else order = 0;
+                    if (arrayValue < value)
+                    {
+                        order = -1;
+                    }
+                    else if (arrayValue > value)
+                    {
+                        order = 1;
+                    }
+                    else
+                    {
+                        order = 0;
+                    }
 
-                    if (order == 0) return i;
+                    if (order == 0)
+                    {
+                        return i;
+                    }
+
                     if (order < 0)
                     {
                         lo = i + 1;
@@ -340,24 +301,19 @@ namespace MessagePack.Internal
 
 #if !NET_STANDARD_2_0
 
-            // SearchNext(ref byte* p, ref int rest, ref ulong key)
-            public void EmitSearchNext(ILGenerator il, LocalBuilder p, LocalBuilder rest, LocalBuilder key, Action<KeyValuePair<string, int>> onFound, Action onNotFound)
+            // SearchNext(ref ReadOnlySpan<byte> bytes)
+            public void EmitSearchNext(ILGenerator il, LocalBuilder bytesSpan, LocalBuilder key, Action<KeyValuePair<string, int>> onFound, Action onNotFound)
             {
-                // key = AutomataKeyGen.GetKey(ref p, ref rest);
-                il.EmitLdloca(p);
-                il.EmitLdloca(rest);
-#if !UNITY
+                // key = AutomataKeyGen.GetKey(ref bytesSpan);
+                il.EmitLdloca(bytesSpan);
                 il.EmitCall(AutomataKeyGen.GetKeyMethod);
-#else
-                il.EmitCall(AutomataKeyGen.GetGetKeyMethod());
-#endif
                 il.EmitStloc(key);
 
                 // match children.
-                EmitSearchNextCore(il, p, rest, key, onFound, onNotFound, nexts, count);
+                EmitSearchNextCore(il, bytesSpan, key, onFound, onNotFound, nexts, count);
             }
 
-            static void EmitSearchNextCore(ILGenerator il, LocalBuilder p, LocalBuilder rest, LocalBuilder key, Action<KeyValuePair<string, int>> onFound, Action onNotFound, AutomataNode[] nexts, int count)
+            private static void EmitSearchNextCore(ILGenerator il, LocalBuilder bytesSpan, LocalBuilder key, Action<KeyValuePair<string, int>> onFound, Action onNotFound, AutomataNode[] nexts, int count)
             {
                 if (count < 4)
                 {
@@ -368,15 +324,17 @@ namespace MessagePack.Internal
                     var gotoNotFound = il.DefineLabel();
 
                     {
-                        il.EmitLdloc(rest);
+                        // bytesSpan.Length
+                        il.EmitLdloca(bytesSpan);
+                        il.EmitCall(typeof(ReadOnlySpan<byte>).GetRuntimeProperty(nameof(ReadOnlySpan<byte>.Length)).GetMethod);
                         if (childrenExists.Length != 0 && valueExists.Length == 0)
                         {
 
-                            il.Emit(OpCodes.Brfalse, gotoNotFound); // if(rest == 0)
+                            il.Emit(OpCodes.Brfalse, gotoNotFound); // if(bytesSpan.Length == 0)
                         }
                         else
                         {
-                            il.Emit(OpCodes.Brtrue, gotoSearchNext); // if(rest != 0)
+                            il.Emit(OpCodes.Brtrue, gotoSearchNext); // if(bytesSpan.Length != 0)
                         }
                     }
                     {
@@ -422,7 +380,7 @@ namespace MessagePack.Internal
                         il.EmitULong(childrenExists[i].Key);
                         il.Emit(OpCodes.Bne_Un, notFoundLabel);
                         // found
-                        childrenExists[i].EmitSearchNext(il, p, rest, key, onFound, onNotFound);
+                        childrenExists[i].EmitSearchNext(il, bytesSpan, key, onFound, onNotFound);
                         // notfound
                         il.MarkLabel(notFoundLabel);
                         if (i != childrenExists.Length - 1)
@@ -452,11 +410,11 @@ namespace MessagePack.Internal
                     il.EmitLdloc(key);
                     il.EmitULong(mid);
                     il.Emit(OpCodes.Bge, gotoRight);
-                    EmitSearchNextCore(il, p, rest, key, onFound, onNotFound, l, l.Length);
+                    EmitSearchNextCore(il, bytesSpan, key, onFound, onNotFound, l, l.Length);
 
                     // else
                     il.MarkLabel(gotoRight);
-                    EmitSearchNextCore(il, p, rest, key, onFound, onNotFound, r, r.Length);
+                    EmitSearchNextCore(il, bytesSpan, key, onFound, onNotFound, r, r.Length);
                 }
             }
 
@@ -466,301 +424,74 @@ namespace MessagePack.Internal
 
     public static class AutomataKeyGen
     {
-        public delegate ulong PointerDelegate<T>(ref T p, ref int rest);
-
 #if !UNITY
-        public static readonly MethodInfo GetKeyMethod = typeof(AutomataKeyGen).GetRuntimeMethod("GetKey", new[] { typeof(byte).MakePointerType().MakeByRefType(), typeof(int).MakeByRefType() });
+        public static readonly MethodInfo GetKeyMethod = typeof(AutomataKeyGen).GetRuntimeMethod(nameof(GetKey), new[] { typeof(ReadOnlySpan<byte>).MakeByRefType() });
 #endif
 
-#if !NETSTANDARD
-
-#if !NET_STANDARD_2_0
-
-        static MethodInfo dynamicGetKeyMethod;
-        static readonly object gate = new object();
-        static DynamicAssembly dynamicAssembly;
-
-        public static MethodInfo GetGetKeyMethod()
+        public static ulong GetKey(ref ReadOnlySpan<byte> span)
         {
-            if (dynamicGetKeyMethod == null)
-            {
-                lock (gate)
-                {
-                    if (dynamicGetKeyMethod == null)
-                    {
-                        dynamicAssembly = new DynamicAssembly("AutomataKeyGenHelper");
-                        var helperType = dynamicAssembly.DefineType("AutomataKeyGen", TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Abstract, null);
-
-                        var dm = helperType.DefineMethod("GetKey", MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig, typeof(ulong), new[] { typeof(byte).MakePointerType().MakeByRefType(), typeof(int).MakeByRefType() });
-
-                        var il = dm.GetILGenerator();
-
-                        il.DeclareLocal(typeof(int)); // var readSize
-                        il.DeclareLocal(typeof(ulong)); // var key = 
-                        il.DeclareLocal(typeof(int)); // var _local = 
-
-                        var elseLabel = il.DefineLabel();
-                        var endLabel = il.DefineLabel();
-                        var case0 = il.DefineLabel();
-                        var case1 = il.DefineLabel();
-                        var case2 = il.DefineLabel();
-                        var case3 = il.DefineLabel();
-                        var case4 = il.DefineLabel();
-                        var case5 = il.DefineLabel();
-                        var case6 = il.DefineLabel();
-                        var case7 = il.DefineLabel();
-
-                        il.Emit(OpCodes.Ldarg_1);
-                        il.Emit(OpCodes.Ldind_I4);
-                        il.Emit(OpCodes.Ldc_I4_8);
-                        il.Emit(OpCodes.Blt_S, elseLabel);
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldind_I8);
-                        il.Emit(OpCodes.Stloc_1);
-                        il.Emit(OpCodes.Ldc_I4_8);
-                        il.Emit(OpCodes.Stloc_0);
-                        il.Emit(OpCodes.Br, endLabel);
-
-                        il.MarkLabel(elseLabel);
-                        il.Emit(OpCodes.Ldarg_1);
-                        il.Emit(OpCodes.Ldind_I4);
-                        il.Emit(OpCodes.Stloc_2);
-                        il.Emit(OpCodes.Ldloc_2);
-                        il.Emit(OpCodes.Switch, new[] { case0, case1, case2, case3, case4, case5, case6, case7 });
-                        il.Emit(OpCodes.Br, case0); // default
-
-                        il.MarkLabel(case1);
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldind_U1);
-                        il.Emit(OpCodes.Conv_U8);
-                        il.Emit(OpCodes.Stloc_1);
-                        il.Emit(OpCodes.Ldc_I4_1);
-                        il.Emit(OpCodes.Stloc_0);
-                        il.Emit(OpCodes.Br, endLabel);
-
-                        il.MarkLabel(case2);
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldind_U2);
-                        il.Emit(OpCodes.Conv_U8);
-                        il.Emit(OpCodes.Stloc_1);
-                        il.Emit(OpCodes.Ldc_I4_2);
-                        il.Emit(OpCodes.Stloc_0);
-                        il.Emit(OpCodes.Br, endLabel);
-
-                        il.MarkLabel(case3);
-                        il.DeclareLocal(typeof(ushort)); // _3
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldind_U1);
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldc_I4_1);
-                        il.Emit(OpCodes.Add);
-                        il.Emit(OpCodes.Ldind_U2);
-                        il.Emit(OpCodes.Stloc_3);
-                        il.Emit(OpCodes.Conv_U8);
-                        il.Emit(OpCodes.Ldloc_3);
-                        il.Emit(OpCodes.Conv_U8);
-                        il.Emit(OpCodes.Ldc_I4_8);
-                        il.Emit(OpCodes.Shl);
-                        il.Emit(OpCodes.Or);
-                        il.Emit(OpCodes.Stloc_1);
-                        il.Emit(OpCodes.Ldc_I4_3);
-                        il.Emit(OpCodes.Stloc_0);
-                        il.Emit(OpCodes.Br, endLabel);
-
-                        il.MarkLabel(case4);
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldind_U4);
-                        il.Emit(OpCodes.Conv_U8);
-                        il.Emit(OpCodes.Stloc_1);
-                        il.Emit(OpCodes.Ldc_I4_4);
-                        il.Emit(OpCodes.Stloc_0);
-                        il.Emit(OpCodes.Br, endLabel);
-
-                        il.MarkLabel(case5);
-                        il.DeclareLocal(typeof(uint)); // _4
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldind_U1);
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldc_I4_1);
-                        il.Emit(OpCodes.Add);
-                        il.Emit(OpCodes.Ldind_U4);
-                        il.Emit(OpCodes.Stloc_S, 4);
-                        il.Emit(OpCodes.Conv_U8);
-                        il.Emit(OpCodes.Ldloc_S, 4);
-                        il.Emit(OpCodes.Conv_U8);
-                        il.Emit(OpCodes.Ldc_I4_8);
-                        il.Emit(OpCodes.Shl);
-                        il.Emit(OpCodes.Or);
-                        il.Emit(OpCodes.Stloc_1);
-                        il.Emit(OpCodes.Ldc_I4_5);
-                        il.Emit(OpCodes.Stloc_0);
-                        il.Emit(OpCodes.Br, endLabel);
-
-                        il.MarkLabel(case6);
-                        il.DeclareLocal(typeof(ulong)); // _5
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldind_U2);
-                        il.Emit(OpCodes.Conv_U8); // [x]
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldc_I4_2);
-                        il.Emit(OpCodes.Add); // [x, y]
-                        il.Emit(OpCodes.Ldind_U4);
-                        il.Emit(OpCodes.Conv_U8);
-                        il.Emit(OpCodes.Stloc_S, 5); // [x]
-                        il.Emit(OpCodes.Ldloc_S, 5);
-                        il.Emit(OpCodes.Ldc_I4_S, 16);
-                        il.Emit(OpCodes.Shl);
-                        il.Emit(OpCodes.Or);
-                        il.Emit(OpCodes.Stloc_1);
-                        il.Emit(OpCodes.Ldc_I4_6);
-                        il.Emit(OpCodes.Stloc_0);
-                        il.Emit(OpCodes.Br, endLabel);
-
-                        il.MarkLabel(case7);
-                        il.DeclareLocal(typeof(ushort)); // _6
-                        il.DeclareLocal(typeof(uint)); // _7
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldind_U1);
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldc_I4_1);
-                        il.Emit(OpCodes.Add);
-                        il.Emit(OpCodes.Ldind_U2);
-                        il.Emit(OpCodes.Stloc_S, 6);
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldc_I4_3);
-                        il.Emit(OpCodes.Add);
-                        il.Emit(OpCodes.Ldind_U4);
-                        il.Emit(OpCodes.Stloc_S, 7);
-                        il.Emit(OpCodes.Conv_U8);
-                        il.Emit(OpCodes.Ldloc_S, 6);
-                        il.Emit(OpCodes.Conv_U8);
-                        il.Emit(OpCodes.Ldc_I4_8);
-                        il.Emit(OpCodes.Shl);
-                        il.Emit(OpCodes.Or);
-                        il.Emit(OpCodes.Ldloc_S, 7);
-                        il.Emit(OpCodes.Conv_U8);
-                        il.Emit(OpCodes.Ldc_I4_S, 24);
-                        il.Emit(OpCodes.Shl);
-                        il.Emit(OpCodes.Or);
-                        il.Emit(OpCodes.Stloc_1);
-                        il.Emit(OpCodes.Ldc_I4_7);
-                        il.Emit(OpCodes.Stloc_0);
-                        il.Emit(OpCodes.Br, endLabel);
-
-                        il.MarkLabel(case0);
-                        il.Emit(OpCodes.Ldstr, "Not Supported Length");
-                        il.Emit(OpCodes.Newobj, typeof(InvalidOperationException).GetConstructor(new[] { typeof(string) }));
-                        il.Emit(OpCodes.Throw);
-
-                        il.MarkLabel(endLabel);
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldarg_0);
-                        il.Emit(OpCodes.Ldind_I);
-                        il.Emit(OpCodes.Ldloc_0);
-                        il.Emit(OpCodes.Add);
-                        il.Emit(OpCodes.Stind_I);
-                        il.Emit(OpCodes.Ldarg_1);
-                        il.Emit(OpCodes.Ldarg_1);
-                        il.Emit(OpCodes.Ldind_I4);
-                        il.Emit(OpCodes.Ldloc_0);
-                        il.Emit(OpCodes.Sub);
-                        il.Emit(OpCodes.Stind_I4);
-                        il.Emit(OpCodes.Ldloc_1);
-                        il.Emit(OpCodes.Ret);
-
-                        var genereatedType = helperType.CreateTypeInfo().AsType();
-                        dynamicGetKeyMethod = genereatedType.GetMethods().First();
-                    }
-                }
-            }
-            
-            return dynamicGetKeyMethod;
-        }
-
-#endif
-
-#endif
-
-#if !UNITY
-
-        public static unsafe ulong GetKey(ref byte* p, ref int rest)
-        {
-            int readSize;
             ulong key;
 
             unchecked
             {
-                if (rest >= 8)
+                if (span.Length >= 8)
                 {
-                    key = *(ulong*)p;
-                    readSize = 8;
+                    key = MemoryMarshal.Cast<byte, ulong>(span)[0];
+                    span = span.Slice(8);
                 }
                 else
                 {
-                    switch (rest)
+                    switch (span.Length)
                     {
                         case 1:
                             {
-                                key = *(byte*)p;
-                                readSize = 1;
+                                key = span[0];
+                                span = span.Slice(1);
                                 break;
                             }
                         case 2:
                             {
-                                key = *(ushort*)p;
-                                readSize = 2;
+                                key = MemoryMarshal.Cast<byte, ushort>(span)[0];
+                                span = span.Slice(2);
                                 break;
                             }
                         case 3:
                             {
-                                var a = *p;
-                                var b = *(ushort*)(p + 1);
-                                key = ((ulong)a | (ulong)b << 8);
-                                readSize = 3;
+                                var a = span[0];
+                                var b = MemoryMarshal.Cast<byte, ushort>(span.Slice(1))[0];
+                                key = (a | (ulong)b << 8);
+                                span = span.Slice(3);
                                 break;
                             }
                         case 4:
                             {
-                                key = *(uint*)p;
-                                readSize = 4;
+                                key = MemoryMarshal.Cast<byte, uint>(span)[0];
+                                span = span.Slice(4);
                                 break;
                             }
                         case 5:
                             {
-                                var a = *p;
-                                var b = *(uint*)(p + 1);
-                                key = ((ulong)a | (ulong)b << 8);
-                                readSize = 5;
+                                var a = span[0];
+                                var b = MemoryMarshal.Cast<byte, uint>(span.Slice(1))[0];
+                                key = (a | (ulong)b << 8);
+                                span = span.Slice(5);
                                 break;
                             }
                         case 6:
                             {
-                                ulong a = *(ushort*)p;
-                                ulong b = *(uint*)(p + 2);
+                                ulong a = MemoryMarshal.Cast<byte, ushort>(span)[0];
+                                ulong b = MemoryMarshal.Cast<byte, uint>(span.Slice(2))[0];
                                 key = (a | (b << 16));
-                                readSize = 6;
+                                span = span.Slice(6);
                                 break;
                             }
                         case 7:
                             {
-                                var a = *(byte*)p;
-                                var b = *(ushort*)(p + 1);
-                                var c = *(uint*)(p + 3);
-                                key = ((ulong)a | (ulong)b << 8 | (ulong)c << 24);
-                                readSize = 7;
+                                var a = span[0];
+                                var b = MemoryMarshal.Cast<byte, ushort>(span.Slice(1))[0];
+                                var c = MemoryMarshal.Cast<byte, uint>(span.Slice(3))[0];
+                                key = (a | (ulong)b << 8 | (ulong)c << 24);
+                                span = span.Slice(7);
                                 break;
                             }
                         default:
@@ -768,156 +499,7 @@ namespace MessagePack.Internal
                     }
                 }
 
-                p += readSize;
-                rest -= readSize;
                 return key;
-            }
-        }
-
-#endif
-
-        public static ulong GetKeySafe(byte[] bytes, ref int offset, ref int rest)
-        {
-            int readSize;
-            ulong key;
-
-            if (BitConverter.IsLittleEndian)
-            {
-                unchecked
-                {
-                    if (rest >= 8)
-                    {
-                        key = (ulong)bytes[offset] << 0 | (ulong)bytes[offset + 1] << 8 | (ulong)bytes[offset + 2] << 16 | (ulong)bytes[offset + 3] << 24
-                            | (ulong)bytes[offset + 4] << 32 | (ulong)bytes[offset + 5] << 40 | (ulong)bytes[offset + 6] << 48 | (ulong)bytes[offset + 7] << 56;
-                        readSize = 8;
-                    }
-                    else
-                    {
-                        switch (rest)
-                        {
-                            case 1:
-                                {
-                                    key = bytes[offset];
-                                    readSize = 1;
-                                    break;
-                                }
-                            case 2:
-                                {
-                                    key = (ulong)bytes[offset] << 0 | (ulong)bytes[offset + 1] << 8;
-                                    readSize = 2;
-                                    break;
-                                }
-                            case 3:
-                                {
-                                    key = (ulong)bytes[offset] << 0 | (ulong)bytes[offset + 1] << 8 | (ulong)bytes[offset + 2] << 16;
-                                    readSize = 3;
-                                    break;
-                                }
-                            case 4:
-                                {
-                                    key = (ulong)bytes[offset] << 0 | (ulong)bytes[offset + 1] << 8 | (ulong)bytes[offset + 2] << 16 | (ulong)bytes[offset + 3] << 24;
-                                    readSize = 4;
-                                    break;
-                                }
-                            case 5:
-                                {
-                                    key = (ulong)bytes[offset] << 0 | (ulong)bytes[offset + 1] << 8 | (ulong)bytes[offset + 2] << 16 | (ulong)bytes[offset + 3] << 24
-                                        | (ulong)bytes[offset + 4] << 32;
-                                    readSize = 5;
-                                    break;
-                                }
-                            case 6:
-                                {
-                                    key = (ulong)bytes[offset] << 0 | (ulong)bytes[offset + 1] << 8 | (ulong)bytes[offset + 2] << 16 | (ulong)bytes[offset + 3] << 24
-                                        | (ulong)bytes[offset + 4] << 32 | (ulong)bytes[offset + 5] << 40;
-                                    readSize = 6;
-                                    break;
-                                }
-                            case 7:
-                                {
-                                    key = (ulong)bytes[offset] << 0 | (ulong)bytes[offset + 1] << 8 | (ulong)bytes[offset + 2] << 16 | (ulong)bytes[offset + 3] << 24
-                                        | (ulong)bytes[offset + 4] << 32 | (ulong)bytes[offset + 5] << 40 | (ulong)bytes[offset + 6] << 48;
-                                    readSize = 7;
-                                    break;
-                                }
-                            default:
-                                throw new InvalidOperationException("Not Supported Length");
-                        }
-                    }
-
-                    offset += readSize;
-                    rest -= readSize;
-                    return key;
-                }
-            }
-            else
-            {
-                unchecked
-                {
-                    if (rest >= 8)
-                    {
-                        key = (ulong)bytes[offset] << 56 | (ulong)bytes[offset + 1] << 48 | (ulong)bytes[offset + 2] << 40 | (ulong)bytes[offset + 3] << 32
-                            | (ulong)bytes[offset + 4] << 24 | (ulong)bytes[offset + 5] << 16 | (ulong)bytes[offset + 6] << 8 | (ulong)bytes[offset + 7];
-                        readSize = 8;
-                    }
-                    else
-                    {
-                        switch (rest)
-                        {
-                            case 1:
-                                {
-                                    key = bytes[offset];
-                                    readSize = 1;
-                                    break;
-                                }
-                            case 2:
-                                {
-                                    key = (ulong)bytes[offset] << 8 | (ulong)bytes[offset + 1] << 0;
-                                    readSize = 2;
-                                    break;
-                                }
-                            case 3:
-                                {
-                                    key = (ulong)bytes[offset] << 16 | (ulong)bytes[offset + 1] << 8 | (ulong)bytes[offset + 2] << 0;
-                                    readSize = 3;
-                                    break;
-                                }
-                            case 4:
-                                {
-                                    key = (ulong)bytes[offset] << 24 | (ulong)bytes[offset + 1] << 16 | (ulong)bytes[offset + 2] << 8 | (ulong)bytes[offset + 3] << 0;
-                                    readSize = 4;
-                                    break;
-                                }
-                            case 5:
-                                {
-                                    key = (ulong)bytes[offset] << 32 | (ulong)bytes[offset + 1] << 24 | (ulong)bytes[offset + 2] << 16 | (ulong)bytes[offset + 3] << 8
-                                        | (ulong)bytes[offset + 4] << 0;
-                                    readSize = 5;
-                                    break;
-                                }
-                            case 6:
-                                {
-                                    key = (ulong)bytes[offset] << 40 | (ulong)bytes[offset + 1] << 32 | (ulong)bytes[offset + 2] << 24 | (ulong)bytes[offset + 3] << 16
-                                        | (ulong)bytes[offset + 4] << 8 | (ulong)bytes[offset + 5] << 0;
-                                    readSize = 6;
-                                    break;
-                                }
-                            case 7:
-                                {
-                                    key = (ulong)bytes[offset] << 48 | (ulong)bytes[offset + 1] << 40 | (ulong)bytes[offset + 2] << 32 | (ulong)bytes[offset + 3] << 24
-                                        | (ulong)bytes[offset + 4] << 16 | (ulong)bytes[offset + 5] << 8 | (ulong)bytes[offset + 6] << 0;
-                                    readSize = 7;
-                                    break;
-                                }
-                            default:
-                                throw new InvalidOperationException("Not Supported Length");
-                        }
-                    }
-
-                    offset += readSize;
-                    rest -= readSize;
-                    return key;
-                }
             }
         }
     }

--- a/src/MessagePack/Internal/ByteArrayComparer.cs
+++ b/src/MessagePack/Internal/ByteArrayComparer.cs
@@ -13,15 +13,15 @@ namespace MessagePack.Internal
         static readonly bool Is32Bit = (IntPtr.Size == 4);
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-        public static int GetHashCode(byte[] bytes, int offset, int count)
+        public static int GetHashCode(ReadOnlySpan<byte> bytes)
         {
             if (Is32Bit)
             {
-                return unchecked((int)FarmHash.Hash32(bytes, offset, count));
+                return unchecked((int)FarmHash.Hash32(bytes));
             }
             else
             {
-                return unchecked((int)FarmHash.Hash64(bytes, offset, count));
+                return unchecked((int)FarmHash.Hash64(bytes));
             }
         }
 
@@ -30,25 +30,17 @@ namespace MessagePack.Internal
 #if !UNITY
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
-        public static unsafe bool Equals(byte[] xs, int xsOffset, int xsCount, byte[] ys)
+        public static unsafe bool Equals(ReadOnlySpan<byte> xs, ReadOnlySpan<byte> ys)
         {
-            return Equals(xs, xsOffset, xsCount, ys, 0, ys.Length);
-        }
-
-#if !UNITY
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-#endif
-        public static unsafe bool Equals(byte[] xs, int xsOffset, int xsCount, byte[] ys, int ysOffset, int ysCount)
-        {
-            if (xs == null || ys == null || xsCount != ysCount)
+            if (xs.Length != ys.Length)
             {
                 return false;
             }
 
-            fixed (byte* p1 = &xs[xsOffset])
-            fixed (byte* p2 = &ys[ysOffset])
+            fixed (byte* p1 = xs)
+            fixed (byte* p2 = ys)
             {
-                switch (xsCount)
+                switch (xs.Length)
                 {
                     case 0:
                         return true;
@@ -76,8 +68,8 @@ namespace MessagePack.Internal
                             var x1 = p1;
                             var x2 = p2;
 
-                            byte* xEnd = p1 + xsCount - 8;
-                            byte* yEnd = p2 + ysCount - 8;
+                            byte* xEnd = p1 + xs.Length - 8;
+                            byte* yEnd = p2 + ys.Length - 8;
 
                             while (x1 < xEnd)
                             {
@@ -100,34 +92,16 @@ namespace MessagePack.Internal
 #if !UNITY
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
-        public static bool Equals(byte[] xs, int xsOffset, int xsCount, byte[] ys)
+        public static bool Equals(ReadOnlySpan<byte> xs, ReadOnlySpan<byte> ys)
         {
-            if (xs == null || ys == null || xsCount != ys.Length)
+            if (xs.Length != ys.Length)
             {
                 return false;
             }
 
             for (int i = 0; i < ys.Length; i++)
             {
-                if (xs[xsOffset++] != ys[i]) return false;
-            }
-
-            return true;
-        }
-
-#if !UNITY
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-#endif
-        public static bool Equals(byte[] xs, int xsOffset, int xsCount, byte[] ys, int ysOffset, int ysCount)
-        {
-            if (xs == null || ys == null || xsCount != ysCount)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < xsCount; i++)
-            {
-                if (xs[xsOffset++] != ys[ysOffset++]) return false;
+                if (xs[i] != ys[i]) return false;
             }
 
             return true;

--- a/src/MessagePack/Internal/CodeGenHelpers.cs
+++ b/src/MessagePack/Internal/CodeGenHelpers.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MessagePack.Internal
+{
+    //[Obsolete("For use in dynamically generated code only.", error: true)]
+    public static class CodeGenHelpers
+    {
+        public static byte[] GetEncodedStringBytes(string value)
+        {
+            var byteCount = StringEncoding.UTF8.GetByteCount(value);
+            if (byteCount <= MessagePackRange.MaxFixStringLength)
+            {
+                var bytes = new byte[byteCount + 1];
+                bytes[0] = (byte)(MessagePackCode.MinFixStr | byteCount);
+                StringEncoding.UTF8.GetBytes(value, 0, value.Length, bytes, 1);
+                return bytes;
+            }
+            else if (byteCount <= byte.MaxValue)
+            {
+                var bytes = new byte[byteCount + 2];
+                bytes[0] = MessagePackCode.Str8;
+                bytes[1] = unchecked((byte)byteCount);
+                StringEncoding.UTF8.GetBytes(value, 0, value.Length, bytes, 2);
+                return bytes;
+            }
+            else if (byteCount <= ushort.MaxValue)
+            {
+                var bytes = new byte[byteCount + 3];
+                bytes[0] = MessagePackCode.Str16;
+                bytes[1] = unchecked((byte)(byteCount >> 8));
+                bytes[2] = unchecked((byte)byteCount);
+                StringEncoding.UTF8.GetBytes(value, 0, value.Length, bytes, 3);
+                return bytes;
+            }
+            else
+            {
+                var bytes = new byte[byteCount + 5];
+                bytes[0] = MessagePackCode.Str32;
+                bytes[1] = unchecked((byte)(byteCount >> 24));
+                bytes[2] = unchecked((byte)(byteCount >> 16));
+                bytes[3] = unchecked((byte)(byteCount >> 8));
+                bytes[4] = unchecked((byte)byteCount);
+                StringEncoding.UTF8.GetBytes(value, 0, value.Length, bytes, 5);
+                return bytes;
+            }
+        }
+
+        public static ReadOnlySpan<byte> GetSpanFromSequence(ReadOnlySequence<byte> sequence)
+        {
+            if (sequence.IsSingleSegment)
+            {
+                return sequence.First.Span;
+            }
+
+            return sequence.ToArray();
+        }
+    }
+}

--- a/src/MessagePack/Internal/FarmHash.cs
+++ b/src/MessagePack/Internal/FarmHash.cs
@@ -1,5 +1,6 @@
 ﻿#if !UNITY
 
+using System;
 using System.Runtime.CompilerServices;
 
 namespace MessagePack.Internal
@@ -11,16 +12,16 @@ namespace MessagePack.Internal
         #region Hash32
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe uint Hash32(byte[] bytes, int offset, int count)
+        public static unsafe uint Hash32(ReadOnlySpan<byte> bytes)
         {
-            if (count <= 4)
+            if (bytes.Length <= 4)
             {
-                return Hash32Len0to4(bytes, offset, (uint)count);
+                return Hash32Len0to4(bytes);
             }
 
-            fixed (byte* p = &bytes[offset])
+            fixed (byte* p = bytes)
             {
-                return Hash32(p, (uint)count);
+                return Hash32(p, (uint)bytes.Length);
             }
         }
 
@@ -72,19 +73,18 @@ namespace MessagePack.Internal
 
         // 0-4
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static unsafe uint Hash32Len0to4(byte[] s, int offset, uint len)
+        static unsafe uint Hash32Len0to4(ReadOnlySpan<byte> s)
         {
             unchecked
             {
                 uint b = 0;
                 uint c = 9;
-                var max = offset + len;
-                for (int i = offset; i < max; i++)
+                for (int i = 0; i < s.Length; i++)
                 {
                     b = b * c1 + s[i];
                     c ^= b;
                 }
-                return fmix(Mur(b, Mur(len, c)));
+                return fmix(Mur(b, Mur((uint)s.Length, c)));
             }
         }
 
@@ -195,11 +195,11 @@ namespace MessagePack.Internal
         // entry point
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ulong Hash64(byte[] bytes, int offset, int count)
+        public static unsafe ulong Hash64(ReadOnlySpan<byte> bytes)
         {
-            fixed (byte* p = &bytes[offset])
+            fixed (byte* p = bytes)
             {
-                return Hash64(p, (uint)count);
+                return Hash64(p, (uint)bytes.Length);
             }
         }
 

--- a/src/MessagePack/Internal/GuidBits.cs
+++ b/src/MessagePack/Internal/GuidBits.cs
@@ -55,104 +55,101 @@ namespace MessagePack.Internal
         }
 
         // 4-pattern, lower/upper and '-' or no
-        public GuidBits(ArraySegment<byte> utf8string)
+        public GuidBits(ReadOnlySpan<byte> utf8string)
         {
             this = default(GuidBits);
 
-            var array = utf8string.Array;
-            var offset = utf8string.Offset;
-
             // 32
-            if (utf8string.Count == 32)
+            if (utf8string.Length == 32)
             {
                 if (BitConverter.IsLittleEndian)
                 {
-                    this.Byte0 = Parse(array, offset + 6);
-                    this.Byte1 = Parse(array, offset + 4);
-                    this.Byte2 = Parse(array, offset + 2);
-                    this.Byte3 = Parse(array, offset + 0);
+                    this.Byte0 = Parse(utf8string, 6);
+                    this.Byte1 = Parse(utf8string, 4);
+                    this.Byte2 = Parse(utf8string, 2);
+                    this.Byte3 = Parse(utf8string, 0);
 
-                    this.Byte4 = Parse(array, offset + 10);
-                    this.Byte5 = Parse(array, offset + 8);
+                    this.Byte4 = Parse(utf8string, 10);
+                    this.Byte5 = Parse(utf8string, 8);
 
-                    this.Byte6 = Parse(array, offset + 14);
-                    this.Byte7 = Parse(array, offset + 12);
+                    this.Byte6 = Parse(utf8string, 14);
+                    this.Byte7 = Parse(utf8string, 12);
                 }
                 else
                 {
-                    this.Byte0 = Parse(array, offset + 0);
-                    this.Byte1 = Parse(array, offset + 2);
-                    this.Byte2 = Parse(array, offset + 4);
-                    this.Byte3 = Parse(array, offset + 6);
+                    this.Byte0 = Parse(utf8string, 0);
+                    this.Byte1 = Parse(utf8string, 2);
+                    this.Byte2 = Parse(utf8string, 4);
+                    this.Byte3 = Parse(utf8string, 6);
 
-                    this.Byte4 = Parse(array, offset + 8);
-                    this.Byte5 = Parse(array, offset + 10);
+                    this.Byte4 = Parse(utf8string, 8);
+                    this.Byte5 = Parse(utf8string, 10);
 
-                    this.Byte6 = Parse(array, offset + 12);
-                    this.Byte7 = Parse(array, offset + 14);
+                    this.Byte6 = Parse(utf8string, 12);
+                    this.Byte7 = Parse(utf8string, 14);
                 }
-                this.Byte8 = Parse(array, offset + 16);
-                this.Byte9 = Parse(array, offset + 18);
+                this.Byte8 = Parse(utf8string, 16);
+                this.Byte9 = Parse(utf8string, 18);
 
-                this.Byte10 = Parse(array, offset + 20);
-                this.Byte11 = Parse(array, offset + 22);
-                this.Byte12 = Parse(array, offset + 24);
-                this.Byte13 = Parse(array, offset + 26);
-                this.Byte14 = Parse(array, offset + 28);
-                this.Byte15 = Parse(array, offset + 30);
+                this.Byte10 = Parse(utf8string, 20);
+                this.Byte11 = Parse(utf8string, 22);
+                this.Byte12 = Parse(utf8string, 24);
+                this.Byte13 = Parse(utf8string, 26);
+                this.Byte14 = Parse(utf8string, 28);
+                this.Byte15 = Parse(utf8string, 30);
                 return;
             }
-            else if (utf8string.Count == 36)
+            else if (utf8string.Length == 36)
             {
                 // '-' => 45
                 if (BitConverter.IsLittleEndian)
                 {
-                    this.Byte0 = Parse(array, offset + 6);
-                    this.Byte1 = Parse(array, offset + 4);
-                    this.Byte2 = Parse(array, offset + 2);
-                    this.Byte3 = Parse(array, offset + 0);
+                    this.Byte0 = Parse(utf8string, 6);
+                    this.Byte1 = Parse(utf8string, 4);
+                    this.Byte2 = Parse(utf8string, 2);
+                    this.Byte3 = Parse(utf8string, 0);
 
-                    if (array[offset + 8] != '-') goto ERROR;
+                    if (utf8string[8] != '-') goto ERROR;
 
-                    this.Byte4 = Parse(array, offset + 11);
-                    this.Byte5 = Parse(array, offset + 9);
+                    this.Byte4 = Parse(utf8string, 11);
+                    this.Byte5 = Parse(utf8string, 9);
 
-                    if (array[offset + 13] != '-') goto ERROR;
+                    if (utf8string[13] != '-') goto ERROR;
 
-                    this.Byte6 = Parse(array, offset + 16);
-                    this.Byte7 = Parse(array, offset + 14);
+                    this.Byte6 = Parse(utf8string, 16);
+                    this.Byte7 = Parse(utf8string, 14);
                 }
                 else
                 {
-                    this.Byte0 = Parse(array, offset + 0);
-                    this.Byte1 = Parse(array, offset + 2);
-                    this.Byte2 = Parse(array, offset + 4);
-                    this.Byte3 = Parse(array, offset + 6);
+                    this.Byte0 = Parse(utf8string, 0);
+                    this.Byte1 = Parse(utf8string, 2);
+                    this.Byte2 = Parse(utf8string, 4);
+                    this.Byte3 = Parse(utf8string, 6);
 
-                    if (array[offset + 8] != '-') goto ERROR;
+                    if (utf8string[8] != '-') goto ERROR;
 
-                    this.Byte4 = Parse(array, offset + 9);
-                    this.Byte5 = Parse(array, offset + 11);
+                    this.Byte4 = Parse(utf8string, 9);
+                    this.Byte5 = Parse(utf8string, 11);
 
-                    if (array[offset + 13] != '-') goto ERROR;
+                    if (utf8string[13] != '-') goto ERROR;
 
-                    this.Byte6 = Parse(array, offset + 14);
-                    this.Byte7 = Parse(array, offset + 16);
+                    this.Byte6 = Parse(utf8string, 14);
+                    this.Byte7 = Parse(utf8string, 16);
                 }
 
-                if (array[offset + 18] != '-') goto ERROR;
+                if (utf8string[18] != '-') goto ERROR;
 
-                this.Byte8 = Parse(array, offset + 19);
-                this.Byte9 = Parse(array, offset + 21);
+                this.Byte8 = Parse(utf8string, 19);
+                this.Byte9 = Parse(utf8string, 21);
 
-                if (array[offset + 23] != '-') goto ERROR;
+                if (utf8string[23] != '-') goto ERROR;
 
-                this.Byte10 = Parse(array, offset + 24);
-                this.Byte11 = Parse(array, offset + 26);
-                this.Byte12 = Parse(array, offset + 28);
-                this.Byte13 = Parse(array, offset + 30);
-                this.Byte14 = Parse(array, offset + 32);
-                this.Byte15 = Parse(array, offset + 34);
+                this.Byte10 = Parse(utf8string, 24);
+                this.Byte11 = Parse(utf8string, 26);
+                this.Byte12 = Parse(utf8string, 28);
+                this.Byte13 = Parse(utf8string, 30);
+                this.Byte14 = Parse(utf8string, 32);
+                this.Byte15 = Parse(utf8string, 34);
                 return;
             }
 
@@ -163,7 +160,7 @@ namespace MessagePack.Internal
 #if !UNITY
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
-        static byte Parse(byte[] bytes, int highOffset)
+        static byte Parse(ReadOnlySpan<byte> bytes, int highOffset)
         {
             return unchecked((byte)(SwitchParse(bytes[highOffset]) * 16 + SwitchParse(bytes[highOffset + 1])));
         }
@@ -290,83 +287,83 @@ namespace MessagePack.Internal
         }
 
         // 4(x2) - 2(x2) - 2(x2) - 2(x2) - 6(x2)
-        public void Write(byte[] buffer, int offset)
+        public void Write(Span<byte> buffer)
         {
             if (BitConverter.IsLittleEndian)
             {
                 // int(_a)
-                buffer[offset + 6] = byteToHexStringHigh[Byte0];
-                buffer[offset + 7] = byteToHexStringLow[Byte0];
-                buffer[offset + 4] = byteToHexStringHigh[Byte1];
-                buffer[offset + 5] = byteToHexStringLow[Byte1];
-                buffer[offset + 2] = byteToHexStringHigh[Byte2];
-                buffer[offset + 3] = byteToHexStringLow[Byte2];
-                buffer[offset + 0] = byteToHexStringHigh[Byte3];
-                buffer[offset + 1] = byteToHexStringLow[Byte3];
+                buffer[6] = byteToHexStringHigh[Byte0];
+                buffer[7] = byteToHexStringLow[Byte0];
+                buffer[4] = byteToHexStringHigh[Byte1];
+                buffer[5] = byteToHexStringLow[Byte1];
+                buffer[2] = byteToHexStringHigh[Byte2];
+                buffer[3] = byteToHexStringLow[Byte2];
+                buffer[0] = byteToHexStringHigh[Byte3];
+                buffer[1] = byteToHexStringLow[Byte3];
 
-                buffer[offset + 8] = (byte)'-';
+                buffer[8] = (byte)'-';
 
                 // short(_b)
-                buffer[offset + 11] = byteToHexStringHigh[Byte4];
-                buffer[offset + 12] = byteToHexStringLow[Byte4];
-                buffer[offset + 9] = byteToHexStringHigh[Byte5];
-                buffer[offset + 10] = byteToHexStringLow[Byte5];
+                buffer[11] = byteToHexStringHigh[Byte4];
+                buffer[12] = byteToHexStringLow[Byte4];
+                buffer[9] = byteToHexStringHigh[Byte5];
+                buffer[10] = byteToHexStringLow[Byte5];
 
-                buffer[offset + 13] = (byte)'-';
+                buffer[13] = (byte)'-';
 
                 // short(_c)
-                buffer[offset + 16] = byteToHexStringHigh[Byte6];
-                buffer[offset + 17] = byteToHexStringLow[Byte6];
-                buffer[offset + 14] = byteToHexStringHigh[Byte7];
-                buffer[offset + 15] = byteToHexStringLow[Byte7];
+                buffer[16] = byteToHexStringHigh[Byte6];
+                buffer[17] = byteToHexStringLow[Byte6];
+                buffer[14] = byteToHexStringHigh[Byte7];
+                buffer[15] = byteToHexStringLow[Byte7];
             }
             else
             {
-                buffer[offset + 0] = byteToHexStringHigh[Byte0];
-                buffer[offset + 1] = byteToHexStringLow[Byte0];
-                buffer[offset + 2] = byteToHexStringHigh[Byte1];
-                buffer[offset + 3] = byteToHexStringLow[Byte1];
-                buffer[offset + 4] = byteToHexStringHigh[Byte2];
-                buffer[offset + 5] = byteToHexStringLow[Byte2];
-                buffer[offset + 6] = byteToHexStringHigh[Byte3];
-                buffer[offset + 7] = byteToHexStringLow[Byte3];
+                buffer[0] = byteToHexStringHigh[Byte0];
+                buffer[1] = byteToHexStringLow[Byte0];
+                buffer[2] = byteToHexStringHigh[Byte1];
+                buffer[3] = byteToHexStringLow[Byte1];
+                buffer[4] = byteToHexStringHigh[Byte2];
+                buffer[5] = byteToHexStringLow[Byte2];
+                buffer[6] = byteToHexStringHigh[Byte3];
+                buffer[7] = byteToHexStringLow[Byte3];
 
-                buffer[offset + 8] = (byte)'-';
+                buffer[8] = (byte)'-';
 
-                buffer[offset + 9] = byteToHexStringHigh[Byte4];
-                buffer[offset + 10] = byteToHexStringLow[Byte4];
-                buffer[offset + 11] = byteToHexStringHigh[Byte5];
-                buffer[offset + 12] = byteToHexStringLow[Byte5];
+                buffer[9] = byteToHexStringHigh[Byte4];
+                buffer[10] = byteToHexStringLow[Byte4];
+                buffer[11] = byteToHexStringHigh[Byte5];
+                buffer[12] = byteToHexStringLow[Byte5];
 
-                buffer[offset + 13] = (byte)'-';
+                buffer[13] = (byte)'-';
 
-                buffer[offset + 14] = byteToHexStringHigh[Byte6];
-                buffer[offset + 15] = byteToHexStringLow[Byte6];
-                buffer[offset + 16] = byteToHexStringHigh[Byte7];
-                buffer[offset + 17] = byteToHexStringLow[Byte7];
+                buffer[14] = byteToHexStringHigh[Byte6];
+                buffer[15] = byteToHexStringLow[Byte6];
+                buffer[16] = byteToHexStringHigh[Byte7];
+                buffer[17] = byteToHexStringLow[Byte7];
             }
 
-            buffer[offset + 18] = (byte)'-';
+            buffer[18] = (byte)'-';
 
-            buffer[offset + 19] = byteToHexStringHigh[Byte8];
-            buffer[offset + 20] = byteToHexStringLow[Byte8];
-            buffer[offset + 21] = byteToHexStringHigh[Byte9];
-            buffer[offset + 22] = byteToHexStringLow[Byte9];
+            buffer[19] = byteToHexStringHigh[Byte8];
+            buffer[20] = byteToHexStringLow[Byte8];
+            buffer[21] = byteToHexStringHigh[Byte9];
+            buffer[22] = byteToHexStringLow[Byte9];
 
-            buffer[offset + 23] = (byte)'-';
+            buffer[23] = (byte)'-';
 
-            buffer[offset + 24] = byteToHexStringHigh[Byte10];
-            buffer[offset + 25] = byteToHexStringLow[Byte10];
-            buffer[offset + 26] = byteToHexStringHigh[Byte11];
-            buffer[offset + 27] = byteToHexStringLow[Byte11];
-            buffer[offset + 28] = byteToHexStringHigh[Byte12];
-            buffer[offset + 29] = byteToHexStringLow[Byte12];
-            buffer[offset + 30] = byteToHexStringHigh[Byte13];
-            buffer[offset + 31] = byteToHexStringLow[Byte13];
-            buffer[offset + 32] = byteToHexStringHigh[Byte14];
-            buffer[offset + 33] = byteToHexStringLow[Byte14];
-            buffer[offset + 34] = byteToHexStringHigh[Byte15];
-            buffer[offset + 35] = byteToHexStringLow[Byte15];
+            buffer[24] = byteToHexStringHigh[Byte10];
+            buffer[25] = byteToHexStringLow[Byte10];
+            buffer[26] = byteToHexStringHigh[Byte11];
+            buffer[27] = byteToHexStringLow[Byte11];
+            buffer[28] = byteToHexStringHigh[Byte12];
+            buffer[29] = byteToHexStringLow[Byte12];
+            buffer[30] = byteToHexStringHigh[Byte13];
+            buffer[31] = byteToHexStringLow[Byte13];
+            buffer[32] = byteToHexStringHigh[Byte14];
+            buffer[33] = byteToHexStringLow[Byte14];
+            buffer[34] = byteToHexStringHigh[Byte15];
+            buffer[35] = byteToHexStringLow[Byte15];
         }
     }
 }

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />

--- a/src/MessagePack/MessagePackBinary.cs
+++ b/src/MessagePack/MessagePackBinary.cs
@@ -4042,7 +4042,7 @@ namespace MessagePack.Decoders
         public Single Read(byte[] bytes, int offset, out int readSize)
         {
             readSize = 5;
-            return new Float32Bits(bytes, offset + 1).Value;
+            return new Float32Bits(bytes.AsSpan(offset + 1)).Value;
         }
     }
 
@@ -4229,7 +4229,7 @@ namespace MessagePack.Decoders
         public Double Read(byte[] bytes, int offset, out int readSize)
         {
             readSize = 5;
-            return new Float32Bits(bytes, offset + 1).Value;
+            return new Float32Bits(bytes.AsSpan(offset + 1)).Value;
         }
     }
 
@@ -4245,7 +4245,7 @@ namespace MessagePack.Decoders
         public Double Read(byte[] bytes, int offset, out int readSize)
         {
             readSize = 9;
-            return new Float64Bits(bytes, offset + 1).Value;
+            return new Float64Bits(bytes.AsSpan(offset + 1)).Value;
         }
     }
 

--- a/src/MessagePack/StringEncoding.cs
+++ b/src/MessagePack/StringEncoding.cs
@@ -1,9 +1,46 @@
-﻿using System.Text;
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace MessagePack
 {
     internal static class StringEncoding
     {
-        public static readonly Encoding UTF8 = new UTF8Encoding(false);
+        internal static readonly Encoding UTF8 = new UTF8Encoding(false);
+
+        internal static unsafe int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
+        {
+            if (chars.Length == 0)
+            {
+                return 0;
+            }
+
+            fixed (char* pChars = &chars[0])
+            fixed (byte* pBytes = &bytes[0])
+            {
+                return encoding.GetBytes(pChars, chars.Length, pBytes, bytes.Length);
+            }
+        }
+
+        internal static unsafe string GetString(this Encoding encoding, ReadOnlyMemory<byte> bytes)
+        {
+            if (bytes.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            if (MemoryMarshal.TryGetArray(bytes, out var segment))
+            {
+                return encoding.GetString(segment.Array, segment.Offset, segment.Count);
+            }
+            else
+            {
+                var tmp = new byte[bytes.Length];
+                bytes.CopyTo(tmp);
+                return encoding.GetString(tmp);
+            }
+        }
+
+        internal static unsafe int GetBytes(this Encoding encoding, string chars, Span<byte> bytes) => GetBytes(encoding, chars.AsSpan(), bytes);
     }
 }

--- a/tests/MessagePack.Tests/AutomataTests.cs
+++ b/tests/MessagePack.Tests/AutomataTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace MessagePack.Tests
 {
-    public class AutomataSafe
+    public class AutomataTests
     {
         [Theory]
         [InlineData("a")]
@@ -21,23 +21,12 @@ namespace MessagePack.Tests
         [InlineData("abcdefgh")]
         public unsafe void KeyGen(string str)
         {
-            var bytes = Encoding.UTF8.GetBytes(str);
-            var rest = bytes.Length;
-            fixed (byte* buf = bytes)
-            {
-                var p = buf;
-                var l1 = AutomataKeyGen.GetKey(ref p, ref rest);
-
-                var offset = 0;
-                rest = bytes.Length;
-                var l2 = AutomataKeyGen.GetKeySafe(bytes, ref offset, ref rest);
-
-                l1.Is(l2);
-            }
+            ReadOnlySpan<byte> bytes = Encoding.UTF8.GetBytes(str);
+            var l1 = AutomataKeyGen.GetKey(ref bytes);
         }
 
         [Fact]
-        public void TryGetValueSafe()
+        public void TryGetValue()
         {
             var keys = new[]
             {
@@ -64,7 +53,7 @@ namespace MessagePack.Tests
             {
                 var enc = Encoding.UTF8.GetBytes(keys[i]);
                 int v;
-                automata.TryGetValueSafe(new ArraySegment<byte>(enc, 0, enc.Length), out v).IsTrue();
+                automata.TryGetValue(enc, out v).IsTrue();
                 v.Is(i);
             }
         }

--- a/tests/MessagePack.Tests/ByteArrayComparerTest.cs
+++ b/tests/MessagePack.Tests/ByteArrayComparerTest.cs
@@ -20,12 +20,12 @@ namespace MessagePack.Tests
                     var xs = Enumerable.Range(1, i).Select(x => (byte)x).ToArray();
                     var ys = xs.ToArray();
 
-                    ByteArrayComparer.Equals(xs, j, xs.Length - j, ys, j, ys.Length - j).IsTrue();
+                    ByteArrayComparer.Equals(xs.AsSpan(j, xs.Length - j), ys.AsSpan(j, ys.Length - j)).IsTrue();
 
                     if (ys.Length != 0)
                     {
                         ys[ys.Length - 1] = 255;
-                        ByteArrayComparer.Equals(xs, j, xs.Length - j, ys, j, ys.Length - j).IsFalse();
+                        ByteArrayComparer.Equals(xs.AsSpan(j, xs.Length - j), ys.AsSpan(j, ys.Length - j)).IsFalse();
                     }
                 }
             }

--- a/tests/MessagePack.Tests/UnsafeMemoryTest.cs
+++ b/tests/MessagePack.Tests/UnsafeMemoryTest.cs
@@ -31,8 +31,8 @@ namespace MessagePack.Tests
             var size = MessagePackBinary.WriteRaw(ref bin3, 0, bin1);
             MessagePackBinary.FastResize(ref bin3, size);
 
-            MessagePack.Internal.ByteArrayComparer.Equals(bin1, 0, bin1.Length, bin2).IsTrue();
-            MessagePack.Internal.ByteArrayComparer.Equals(bin1, 0, bin1.Length, bin3).IsTrue();
+            MessagePack.Internal.ByteArrayComparer.Equals(bin1, bin2).IsTrue();
+            MessagePack.Internal.ByteArrayComparer.Equals(bin1, bin3).IsTrue();
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace MessagePack.Tests
                 var len = ((typeof(UnsafeMemory32).GetMethod("WriteRaw" + i)).CreateDelegate(typeof(WriteDelegate)) as WriteDelegate).Invoke(ref dst, 0, src);
                 len.Is(i);
                 MessagePackBinary.FastResize(ref dst, len);
-                MessagePack.Internal.ByteArrayComparer.Equals(src, 0, src.Length, dst).IsTrue();
+                MessagePack.Internal.ByteArrayComparer.Equals(src, dst).IsTrue();
             }
             // x64
             for (int i = 1; i <= MessagePackRange.MaxFixStringLength; i++)
@@ -56,7 +56,7 @@ namespace MessagePack.Tests
                 var len = ((typeof(UnsafeMemory64).GetMethod("WriteRaw" + i)).CreateDelegate(typeof(WriteDelegate)) as WriteDelegate).Invoke(ref dst, 0, src);
                 len.Is(i);
                 MessagePackBinary.FastResize(ref dst, len);
-                MessagePack.Internal.ByteArrayComparer.Equals(src, 0, src.Length, dst).IsTrue();
+                MessagePack.Internal.ByteArrayComparer.Equals(src, dst).IsTrue();
             }
             // x86, offset
             for (int i = 1; i <= MessagePackRange.MaxFixStringLength; i++)
@@ -66,7 +66,7 @@ namespace MessagePack.Tests
                 var len = ((typeof(UnsafeMemory32).GetMethod("WriteRaw" + i)).CreateDelegate(typeof(WriteDelegate)) as WriteDelegate).Invoke(ref dst, 3, src);
                 len.Is(i);
                 dst = dst.Skip(3).Take(len).ToArray();
-                MessagePack.Internal.ByteArrayComparer.Equals(src, 0, src.Length, dst).IsTrue();
+                MessagePack.Internal.ByteArrayComparer.Equals(src, dst).IsTrue();
             }
             // x64, offset
             for (int i = 1; i <= MessagePackRange.MaxFixStringLength; i++)
@@ -76,7 +76,7 @@ namespace MessagePack.Tests
                 var len = ((typeof(UnsafeMemory64).GetMethod("WriteRaw" + i)).CreateDelegate(typeof(WriteDelegate)) as WriteDelegate).Invoke(ref dst, 3, src);
                 len.Is(i);
                 dst = dst.Skip(3).Take(len).ToArray();
-                MessagePack.Internal.ByteArrayComparer.Equals(src, 0, src.Length, dst).IsTrue();
+                MessagePack.Internal.ByteArrayComparer.Equals(src, dst).IsTrue();
             }
         }
     }


### PR DESCRIPTION
This gives more flexibility for what kinds of data methods can receive. In particular, it gets us closer to supporting reading from ReadOnlySequence<byte> instead of always a byte[].