### PR TITLE
Remove .NET native DateTime support from the MessagePackReader

### DIFF
--- a/src/MessagePack/Formatters/OldSpecFormatter.cs
+++ b/src/MessagePack/Formatters/OldSpecFormatter.cs
@@ -18,7 +18,8 @@ namespace MessagePack.Formatters
 
         public DateTime Deserialize(ref MessagePackReader reader, IFormatterResolver resolver)
         {
-            return reader.ReadDateTime();
+            var dateData = reader.ReadInt64();
+            return DateTime.FromBinary(dateData);
         }
     }
 

--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -771,22 +771,9 @@ namespace MessagePack
         /// <see cref="MessagePackCode.FixExt8"/>, or
         /// <see cref="MessagePackCode.Ext8"/>.
         /// Expects extension type code <see cref="ReservedMessagePackExtensionTypeCode.DateTime"/>.
-        /// If the reader is not positioned at an extension, a .NET native <see cref="DateTime"/> binary format will be read
-        /// as an integer (this format is written in old spec mode).
         /// </summary>
         /// <returns>The value.</returns>
-        public DateTime ReadDateTime()
-        {
-            if (this.NextMessagePackType != MessagePackType.Extension)
-            {
-                // OldSpec compatibility
-                return DateTime.FromBinary(this.ReadInt64());
-            }
-            else
-            {
-                return ReadDateTime(ReadExtensionFormatHeader());
-            }
-        }
+        public DateTime ReadDateTime() => ReadDateTime(ReadExtensionFormatHeader());
 
         /// <summary>
         /// Reads a <see cref="DateTime"/> from a value encoded with


### PR DESCRIPTION
This format isn't in the MsgPack spec, so we don't want it in the MsgPack primitive reader.

Also remove support for the spec-compliant DateTime format from NativeDateTimeFormatter, since it is neither the native format nor is it supported by the array-variant of that same formatter, which seems inconsistent and may lead to customer confusion.

As @neuecc pointed out was needed [here](https://github.com/AArnott/MessagePack-CSharp/pull/40#issuecomment-468949101).