### PR TITLE
MessagePackSerializer API refinements

### DIFF
--- a/src/MessagePack/BufferWriter.cs
+++ b/src/MessagePack/BufferWriter.cs
@@ -50,7 +50,7 @@ namespace MessagePack
         {
             _buffered = 0;
             _bytesCommitted = 0;
-            _output = output;
+            _output = output ?? throw new ArgumentNullException(nameof(output));
 
             var memory = _output.GetMemory();
             MemoryMarshal.TryGetArray(memory, out _segment);

--- a/src/MessagePack/MessagePackSerializer+NonGeneric.cs
+++ b/src/MessagePack/MessagePackSerializer+NonGeneric.cs
@@ -51,11 +51,6 @@ namespace MessagePack
                 GetOrAdd(type).serialize4.Invoke(this.serializer, stream, obj, resolver);
             }
 
-            public object Deserialize(Type type, byte[] bytes, int offset = 0, IFormatterResolver resolver = null)
-            {
-                return GetOrAdd(type).deserialize2.Invoke(this.serializer, bytes, offset, resolver);
-            }
-
             public object Deserialize(Type type, Stream stream, IFormatterResolver resolver = null)
             {
                 return GetOrAdd(type).deserialize4.Invoke(this.serializer, stream, resolver);
@@ -76,7 +71,6 @@ namespace MessagePack
                 public readonly Func<MessagePackSerializer, object, IFormatterResolver, byte[]> serialize2;
                 public readonly Action<MessagePackSerializer, Stream, object, IFormatterResolver> serialize4;
 
-                public readonly Func<MessagePackSerializer, byte[], int, IFormatterResolver, object> deserialize2;
                 public readonly Func<MessagePackSerializer, Stream, IFormatterResolver, object> deserialize4;
 
                 public readonly Func<MessagePackSerializer, Memory<byte>, IFormatterResolver, object> deserialize8;
@@ -118,18 +112,6 @@ namespace MessagePack
                         var lambda = Expression.Lambda<Action<MessagePackSerializer, Stream, object, IFormatterResolver>>(body, param0, param1, param2, param3).Compile();
 
                         this.serialize4 = lambda;
-                    }
-                    {
-                        // public static T Deserialize<T>(byte[] bytes, int offset, IFormatterResolver resolver)
-                        var deserialize = GetMethod(type, new Type[] { typeof(byte[]), typeof(int), typeof(IFormatterResolver) });
-
-                        var param1 = Expression.Parameter(typeof(byte[]), "bytes");
-                        var param2 = Expression.Parameter(typeof(int), "offset");
-                        var param3 = Expression.Parameter(typeof(IFormatterResolver), "resolver");
-                        var body = Expression.Convert(Expression.Call(param0, deserialize, param1, param2, param3), typeof(object));
-                        var lambda = Expression.Lambda<Func<MessagePackSerializer, byte[], int, IFormatterResolver, object>>(body, param0, param1, param2, param3).Compile();
-
-                        this.deserialize2 = lambda;
                     }
                     {
                         // public static T Deserialize<T>(Stream stream, IFormatterResolver resolver)

--- a/src/MessagePack/MessagePackSerializer+Typeless.cs
+++ b/src/MessagePack/MessagePackSerializer+Typeless.cs
@@ -1,6 +1,7 @@
 ﻿#if !UNITY
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,17 +27,23 @@ namespace MessagePack
                 this.serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             }
 
+            public void Serialize(ref MessagePackWriter writer, object obj) => serializer.Serialize(ref writer, obj);
+
+            public void Serialize(IBufferWriter<byte> writer, object obj) => serializer.Serialize(writer, obj);
+
             public byte[] Serialize(object obj) => serializer.Serialize(obj);
 
             public void Serialize(Stream stream, object obj) => serializer.Serialize(stream, obj);
 
             public ValueTask SerializeAsync(Stream stream, object obj, CancellationToken cancellationToken) => serializer.SerializeAsync(stream, obj, cancellationToken: cancellationToken);
 
-            public object Deserialize(byte[] bytes) => serializer.Deserialize<object>(bytes);
+            public object Deserialize(ref MessagePackReader reader) => serializer.Deserialize<object>(ref reader);
+
+            public object Deserialize(ReadOnlySequence<byte> byteSequence) => serializer.Deserialize<object>(byteSequence);
 
             public object Deserialize(Stream stream) => serializer.Deserialize<object>(stream);
 
-            public object Deserialize(ArraySegment<byte> bytes) => serializer.Deserialize<object>(bytes);
+            public object Deserialize(Memory<byte> bytes) => serializer.Deserialize<object>(bytes);
 
             public ValueTask<object> DeserializeAsync(Stream stream, CancellationToken cancellationToken = default) => serializer.DeserializeAsync<object>(stream, cancellationToken: cancellationToken);
         }

--- a/src/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack/MessagePackSerializer.cs
@@ -54,16 +54,6 @@ namespace MessagePack
         /// <param name="resolver">The resolver to use during deserialization. Use <c>null</c> to use the <see cref="DefaultResolver"/>.</param>
         public void Serialize<T>(IBufferWriter<byte> writer, T value, IFormatterResolver resolver = null)
         {
-            if (writer == null)
-            {
-                throw new ArgumentNullException(nameof(writer));
-            }
-
-            if (resolver == null)
-            {
-                resolver = this.DefaultResolver;
-            }
-
             var fastWriter = new MessagePackWriter(writer);
             this.Serialize(ref fastWriter, value, resolver);
             fastWriter.Flush();
@@ -172,38 +162,13 @@ namespace MessagePack
         /// Deserializes a value of a given type from a sequence of bytes.
         /// </summary>
         /// <typeparam name="T">The type of value to deserialize.</typeparam>
-        /// <param name="buffer">The array to deserialize from.</param>
-        /// <param name="offset">The position in the array to start deserialization.</param>
-        /// <param name="resolver">The resolver to use during deserialization. Use <c>null</c> to use the <see cref="DefaultResolver"/>.</param>
-        /// <returns>The deserialized value.</returns>
-        public T Deserialize<T>(byte[] buffer, int offset = 0, IFormatterResolver resolver = null)
-        {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-
-            var reader = new MessagePackReader(new ReadOnlySequence<byte>(buffer.AsMemory(offset)));
-            return Deserialize<T>(ref reader, resolver);
-        }
-
-        /// <summary>
-        /// Deserializes a value of a given type from a sequence of bytes.
-        /// </summary>
-        /// <typeparam name="T">The type of value to deserialize.</typeparam>
-        /// <param name="buffer">The array to deserialize from.</param>
-        /// <param name="offset">The position in the array to start deserialization.</param>
+        /// <param name="buffer">The memory to deserialize from.</param>
         /// <param name="resolver">The resolver to use during deserialization. Use <c>null</c> to use the <see cref="DefaultResolver"/>.</param>
         /// <param name="bytesRead">The number of bytes read.</param>
         /// <returns>The deserialized value.</returns>
-        public T Deserialize<T>(byte[] buffer, int offset, IFormatterResolver resolver, out int bytesRead)
+        public T Deserialize<T>(Memory<byte> buffer, IFormatterResolver resolver, out int bytesRead)
         {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-
-            var sequence = new ReadOnlySequence<byte>(buffer.AsMemory(offset));
+            var sequence = new ReadOnlySequence<byte>(buffer);
             var reader = new MessagePackReader(sequence);
             T result = Deserialize<T>(ref reader, resolver);
             bytesRead = (int)sequence.Slice(0, reader.Position).Length;


### PR DESCRIPTION
Add some missing overloads to Typeless class.
Remove byte[] overloads where Memory<byte> will suffice.