### PR TITLE
Deserialize ReadOnlyMemory<T>

### DIFF
--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -52,6 +52,11 @@ namespace MessagePack
         public SequencePosition Position => this.reader.Position;
 
         /// <summary>
+        /// Gets the number of bytes consumed by the reader.
+        /// </summary>
+        public long Consumed => this.reader.Consumed;
+
+        /// <summary>
         /// Gets a value indicating whether the reader is at the end of the sequence.
         /// </summary>
         public bool End => this.reader.End;

--- a/src/MessagePack/MessagePackSerializer+NonGeneric.cs
+++ b/src/MessagePack/MessagePackSerializer+NonGeneric.cs
@@ -73,7 +73,7 @@ namespace MessagePack
 
                 public readonly Func<MessagePackSerializer, Stream, IFormatterResolver, object> deserialize4;
 
-                public readonly Func<MessagePackSerializer, Memory<byte>, IFormatterResolver, object> deserialize8;
+                public readonly Func<MessagePackSerializer, ReadOnlyMemory<byte>, IFormatterResolver, object> deserialize8;
 
                 public CompiledMethods(Type type)
                 {
@@ -126,13 +126,13 @@ namespace MessagePack
                     }
 
                     {
-                        // public static T Deserialize<T>(Memory<byte> bytes, IFormatterResolver resolver)
-                        var deserialize = GetMethod(type, new Type[] { typeof(Memory<byte>), typeof(IFormatterResolver) });
+                        // public static T Deserialize<T>(ReadOnlyMemory<byte> bytes, IFormatterResolver resolver)
+                        var deserialize = GetMethod(type, new Type[] { typeof(ReadOnlyMemory<byte>), typeof(IFormatterResolver) });
 
-                        var param1 = Expression.Parameter(typeof(Memory<byte>), "bytes");
+                        var param1 = Expression.Parameter(typeof(ReadOnlyMemory<byte>), "bytes");
                         var param2 = Expression.Parameter(typeof(IFormatterResolver), "resolver");
                         var body = Expression.Convert(Expression.Call(param0, deserialize, param1, param2), typeof(object));
-                        var lambda = Expression.Lambda<Func<MessagePackSerializer, Memory<byte>, IFormatterResolver, object>>(body, param0, param1, param2).Compile();
+                        var lambda = Expression.Lambda<Func<MessagePackSerializer, ReadOnlyMemory<byte>, IFormatterResolver, object>>(body, param0, param1, param2).Compile();
 
                         this.deserialize8 = lambda;
                     }

--- a/src/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack/MessagePackSerializer.cs
@@ -152,7 +152,7 @@ namespace MessagePack
         /// <param name="buffer">The buffer to deserialize from.</param>
         /// <param name="resolver">The resolver to use during deserialization. Use <c>null</c> to use the <see cref="DefaultResolver"/>.</param>
         /// <returns>The deserialized value.</returns>
-        public T Deserialize<T>(Memory<byte> buffer, IFormatterResolver resolver = null)
+        public T Deserialize<T>(ReadOnlyMemory<byte> buffer, IFormatterResolver resolver = null)
         {
             var reader = new MessagePackReader(new ReadOnlySequence<byte>(buffer));
             return this.Deserialize<T>(ref reader, resolver);
@@ -166,7 +166,7 @@ namespace MessagePack
         /// <param name="resolver">The resolver to use during deserialization. Use <c>null</c> to use the <see cref="DefaultResolver"/>.</param>
         /// <param name="bytesRead">The number of bytes read.</param>
         /// <returns>The deserialized value.</returns>
-        public T Deserialize<T>(Memory<byte> buffer, IFormatterResolver resolver, out int bytesRead)
+        public T Deserialize<T>(ReadOnlyMemory<byte> buffer, IFormatterResolver resolver, out int bytesRead)
         {
             var sequence = new ReadOnlySequence<byte>(buffer);
             var reader = new MessagePackReader(sequence);

--- a/src/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack/MessagePackSerializer.cs
@@ -154,7 +154,7 @@ namespace MessagePack
         /// <returns>The deserialized value.</returns>
         public T Deserialize<T>(ReadOnlyMemory<byte> buffer, IFormatterResolver resolver = null)
         {
-            var reader = new MessagePackReader(new ReadOnlySequence<byte>(buffer));
+            var reader = new MessagePackReader(buffer);
             return this.Deserialize<T>(ref reader, resolver);
         }
 
@@ -168,10 +168,9 @@ namespace MessagePack
         /// <returns>The deserialized value.</returns>
         public T Deserialize<T>(ReadOnlyMemory<byte> buffer, IFormatterResolver resolver, out int bytesRead)
         {
-            var sequence = new ReadOnlySequence<byte>(buffer);
-            var reader = new MessagePackReader(sequence);
+            var reader = new MessagePackReader(buffer);
             T result = Deserialize<T>(ref reader, resolver);
-            bytesRead = (int)sequence.Slice(0, reader.Position).Length;
+            bytesRead = buffer.Slice(0, (int)reader.Consumed).Length;
             return result;
         }
 


### PR DESCRIPTION
Take ReadOnlyMemory<byte> in MessagePackSerializer.Deserialize<T> 

This is in preparation for a fix to #46 