### PR TITLE
Optimize MessagePackReader for contiguous memory

### DIFF
--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -28,8 +28,8 @@ namespace MessagePack
         /// </summary>
         /// <param name="memory">The buffer to read from.</param>
         public MessagePackReader(ReadOnlyMemory<byte> memory)
-            : this(new ReadOnlySequence<byte>(memory))
         {
+            this.reader = new SequenceReader<byte>(memory);
         }
 
         /// <summary>


### PR DESCRIPTION
ReadOnlySequence<T> is expensive compared to Memory<T>, and this shows up markedly for small deserialization buffers (e.g. deserializing an integer).
This commit adds support for skipping ReadOnlySequence<T> entirely for cases where we have contiguous memory. We may lazily create the sequence if the caller demands it however.

This makes short, contiguous buffer reads significantly faster. For example the benchmark below runs 41% faster:

**Before**

Benchmark | Implementation | Elapsed time
-- | -- | -- |
_PrimitiveIntDeserialize | MessagePack_v1 | 25.03 ns
_PrimitiveIntDeserialize | MessagePack_v2 (before) | 154.18 ns
_PrimitiveIntDeserialize | MessagePack_v2 (after) | 91.50 ns

Part of fix for #46 