### PR TITLE
Optimize tiny serialization jobs

### DIFF
--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -76,6 +76,9 @@
     <Compile Include="..\..\src\MessagePack\MessagePackWriter.cs">
       <Link>Code\MessagePackWriter.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\MessagePack\SequencePool.cs">
+      <Link>Code\SequencePool.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\MessagePack\SequenceReader.cs">
       <Link>Code\SequenceReader.cs</Link>
     </Compile>


### PR DESCRIPTION
We altogether skip the IBufferWriter<byte> if the serialized result is <= 64KB when the caller wants a byte[] result. This increases tiny serialization perf by 64%

Substantial fix for #46