### PR TITLE
Fix handling of collecting nullable reference type names

### DIFF
--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -1078,17 +1078,10 @@ namespace MessagePackCompiler.CodeAnalysis
             }
 
             // constraint types (IDisposable, IEnumerable ...)
-            foreach (var (t, index) in typeParameter.ConstraintTypes.Select((x, i) => (x, i)))
+            foreach (var t in typeParameter.ConstraintTypes)
             {
                 var constraintTypeFullName = t.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.AddMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier));
-                if (typeParameter.ConstraintNullableAnnotations[index] == NullableAnnotation.Annotated)
-                {
-                    constraints.Add(constraintTypeFullName + "?");
-                }
-                else
-                {
-                    constraints.Add(constraintTypeFullName);
-                }
+                constraints.Add(constraintTypeFullName);
             }
 
             // `new()` constraint must be last in constraints.

--- a/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
@@ -681,20 +681,21 @@ namespace TempProject
 
             var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
 
-            var formatterType = symbols.FirstOrDefault(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.Generated.Formatters.TempProject.MyGenericObjectFormatter<T1, T2, T3, T4>");
+            var displayFormat = SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
+            var formatterType = symbols.FirstOrDefault(x => x.ToDisplayString(displayFormat) == "global::TempProject.Generated.Formatters.TempProject.MyGenericObjectFormatter<T1, T2, T3, T4>");
             formatterType.Should().NotBeNull();
             // MyClass?
-            formatterType.TypeParameters[0].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.MyClass");
+            formatterType.TypeParameters[0].ConstraintTypes.Should().Contain(x => x.ToDisplayString(displayFormat) == "global::TempProject.MyClass?");
             formatterType.TypeParameters[0].ConstraintNullableAnnotations[0].Should().Be(NullableAnnotation.Annotated);
             // MyClass
-            formatterType.TypeParameters[1].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.MyClass");
+            formatterType.TypeParameters[1].ConstraintTypes.Should().Contain(x => x.ToDisplayString(displayFormat) == "global::TempProject.MyClass");
             formatterType.TypeParameters[1].ConstraintNullableAnnotations[0].Should().Be(NullableAnnotation.None);
             // MyGenericClass<MyGenericClass<MyClass?>?>?
-            formatterType.TypeParameters[2].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier)) == "global::TempProject.MyGenericClass<global::TempProject.MyGenericClass<global::TempProject.MyClass?>?>");
+            formatterType.TypeParameters[2].ConstraintTypes.Should().Contain(x => x.ToDisplayString(displayFormat) == "global::TempProject.MyGenericClass<global::TempProject.MyGenericClass<global::TempProject.MyClass?>?>?");
             formatterType.TypeParameters[2].ConstraintNullableAnnotations[0].Should().Be(NullableAnnotation.Annotated);
             // MyClass, IMyInterface?
-            formatterType.TypeParameters[3].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.MyClass");
-            formatterType.TypeParameters[3].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.IMyInterface");
+            formatterType.TypeParameters[3].ConstraintTypes.Should().Contain(x => x.ToDisplayString(displayFormat) == "global::TempProject.MyClass");
+            formatterType.TypeParameters[3].ConstraintTypes.Should().Contain(x => x.ToDisplayString(displayFormat) == "global::TempProject.IMyInterface?");
             formatterType.TypeParameters[3].ConstraintNullableAnnotations[0].Should().Be(NullableAnnotation.None);
             formatterType.TypeParameters[3].ConstraintNullableAnnotations[1].Should().Be(NullableAnnotation.Annotated);
         }


### PR DESCRIPTION
https://github.com/neuecc/MessagePack-CSharp/pull/1068#issuecomment-699639336

Fixed a problem with the difference in the behavior of `ITypeSymbols.ToDisplayString` between 3.4.0 and 3.6.0 of Microsoft.CodeAnalysis.CSharp.

In 3.4.0 the following code returns `MyClass`.

```csharp
INamedTypeSymbol = /* GenericObject<T> where T: MyClass? */
ITypeParameter typeParameter = type.TypeParameters[0];
ITypeSymbol constraintType = typeParameter.ConstraintTypes[0]; /* MyClass? */

var symbolDisplayFormat = SymbolDisplayFormat.FullyQualifiedFormat.AddMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
constraintType.ToDisplayString(symbolDisplayFormat);
```

In 3.6.0 returns `MyClass?` with nullable annotation as expected.
